### PR TITLE
Use shared grammar file from powerquery-language

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grammars": [
       {
         "language": "powerquery",
-        "scopeName": "text.powerquery",
+        "scopeName": "source.powerquery",
         "path": "./syntaxes/powerquery.tmLanguage.json"
       }
     ]

--- a/syntaxes/powerquery.tmLanguage.json
+++ b/syntaxes/powerquery.tmLanguage.json
@@ -1,82 +1,346 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "powerquery",
-	"patterns": [
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"constants": {
-			"patterns": [
-				{
-					"name": "entity.constant.numeric.powerquery",
-					"match": "\\b(0[xX][a-fA-F0-9]+)\\b"
-				},
-				{
-					"name": "entity.constant.numeric.powerquery",
-					"match": "\\b(([0-9]*\\.[0-9]+)|([0-9]+))([eE][\\+\\-]?[0-9]+)?\\b"
-				}
-			]
-		},
-		"hashshared": {
-			"patterns": [
-				{
-					"name": "constant.numeric.powerquery",
-					"match": "\\b((SapBusinessWarehouseExecutionMode.BasXmlGzip)|(SapBusinessWarehouseExecutionMode.DataStream)|(SapHanaRangeOperator.GreaterThanOrEquals)|(SapBusinessWarehouseExecutionMode.BasXml)|(SapHanaRangeOperator.LessThanOrEquals)|(SapHanaRangeOperator.GreaterThan)|(SapHanaDistribution.Connection)|(SapHanaRangeOperator.NotEquals)|(SapHanaRangeOperator.LessThan)|(TextEncoding.BigEndianUnicode)|(SapHanaDistribution.Statement)|(CsvStyle.QuoteAfterDelimiter)|(LimitClauseKind.LimitOffset)|(LimitClauseKind.AnsiSql2008)|(SapHanaRangeOperator.Equals)|(RelativePosition.FromStart)|(JoinAlgorithm.PairwiseHash)|(BinaryOccurrence.Repeating)|(BinaryOccurrence.Optional)|(BinaryOccurrence.Required)|(RoundingMode.AwayFromZero)|(RelativePosition.FromEnd)|(JoinAlgorithm.RightIndex)|(SapHanaDistribution.Off)|(JoinAlgorithm.SortMerge)|(RoundingMode.TowardZero)|(SapHanaDistribution.All)|(JoinAlgorithm.RightHash)|(JoinAlgorithm.LeftIndex)|(Number.PositiveInfinity)|(Number.NegativeInfinity)|(ByteOrder.LittleEndian)|(SparkProtocol.Standard)|(JoinAlgorithm.LeftHash)|(TraceLevel.Information)|(BinaryEncoding.Base64)|(JoinAlgorithm.Dynamic)|(LimitClauseKind.Limit)|(LimitClauseKind.None)|(CsvStyle.QuoteAlways)|(TextEncoding.Unicode)|(TextEncoding.Windows)|(MissingField.UseNull)|(Occurrence.Repeating)|(Occurrence.Optional)|(ByteOrder.BigEndian)|(Compression.Deflate)|(LimitClauseKind.Top)|(MissingField.Ignore)|(Occurrence.Required)|(SparkProtocol.Azure)|(TraceLevel.Critical)|(JoinKind.RightOuter)|(RoundingMode.ToEven)|(MissingField.Error)|(BinaryEncoding.Hex)|(JoinKind.LeftOuter)|(TextEncoding.Utf16)|(TraceLevel.Verbose)|(ExtraValues.Ignore)|(SparkProtocol.HTTP)|(TextEncoding.Ascii)|(JoinKind.FullOuter)|(TraceLevel.Warning)|(JoinKind.RightAnti)|(ExtraValues.Error)|(Precision.Decimal)|(RoundingMode.Down)|(JoinKind.LeftAnti)|(TextEncoding.Utf8)|(Compression.GZip)|(ExtraValues.List)|(Occurrence.First)|(Precision.Double)|(GroupKind.Global)|(Order.Descending)|(TraceLevel.Error)|(GroupKind.Local)|(Order.Ascending)|(QuoteStyle.None)|(RoundingMode.Up)|(Occurrence.Last)|(JoinKind.Inner)|(JoinSide.Right)|(QuoteStyle.Csv)|(Occurrence.All)|(Number.Epsilon)|(JoinSide.Left)|(Day.Wednesday)|(Day.Thursday)|(Day.Saturday)|(Day.Tuesday)|(Day.Sunday)|(Day.Monday)|(Day.Friday)|(Number.NaN)|(Number.PI)|(Number.E))\\b"
-				},
-				{
-					"name": "entity.constant.other.powerquery",
-					"match": "\\b((WebMethod.Delete)|(WebMethod.Patch)|(WebMethod.Head)|(WebMethod.Post)|(WebMethod.Get)|(WebMethod.Put))\\b"
-				},
-				{
-					"name": "entity.name.function.powerquery",
-					"match": "\\b((Dynamics365BusinessCentralOnPremises.Contents)|(EmigoDataSourceConnector.GetExtractFunction)|(MicrosoftAzureConsumptionInsights.Contents)|(MicrosoftAzureConsumptionInsights.Tables)|(BinaryFormat.7BitEncodedUnsignedInteger)|(Splitter.SplitTextByCharacterTransition)|(MicrosoftAzureConsumptionInsights.Test)|(BinaryFormat.7BitEncodedSignedInteger)|(Combiner.CombineTextByEachDelimiter)|(Dynamics365BusinessCentral.Contents)|(PlanviewEnterprise.CallQueryService)|(Splitter.SplitTextByRepeatedLengths)|(AzureDevOpsServer.AccountContents)|(Splitter.SplitTextByEachDelimiter)|(Table.ReplaceRelationshipIdentity)|(AzureDevOpsServer.AnalyticsViews)|(Cube.AddAndExpandDimensionColumn)|(Splitter.SplitTextByAnyDelimiter)|(Combiner.CombineTextByDelimiter)|(Combiner.CombineTextByPositions)|(MicrosoftGraphSecurity.Contents)|(Type.FunctionRequiredParameters)|(BinaryFormat.UnsignedInteger16)|(BinaryFormat.UnsignedInteger32)|(BinaryFormat.UnsignedInteger64)|(Dynamics365Financials.Contents)|(Splitter.SplitTextByWhitespace)|(AzureStorage.DataLakeContents)|(Combiner.CombineTextByLengths)|(Cube.CollapseAndRemoveColumns)|(DateTime.IsInPreviousNMinutes)|(DateTime.IsInPreviousNSeconds)|(Splitter.SplitTextByDelimiter)|(Splitter.SplitTextByPositions)|(BinaryFormat.SignedInteger16)|(BinaryFormat.SignedInteger32)|(BinaryFormat.SignedInteger64)|(Combiner.CombineTextByRanges)|(Cube.AttributeMemberProperty)|(DirectQueryCapabilities.From)|(WorkforceDimensions.Contents)|(DateTime.IsInPreviousMinute)|(DateTime.IsInPreviousNHours)|(DateTime.IsInPreviousSecond)|(Splitter.SplitTextByLengths)|(AnalysisServices.Databases)|(Comparer.OrdinalIgnoreCase)|(Date.IsInPreviousNQuarters)|(DateTime.IsInCurrentMinute)|(DateTime.IsInCurrentSecond)|(DateTimeZone.FixedLocalNow)|(SapBusinessWarehouse.Cubes)|(Splitter.SplitTextByRanges)|(SqlExpression.ToExpression)|(Table.AggregateTableColumn)|(Table.RemoveRowsWithErrors)|(Table.SelectRowsWithErrors)|(Table.TransformColumnNames)|(Table.TransformColumnTypes)|(AnalysisServices.Database)|(AzureStorage.BlobContents)|(DateTime.IsInNextNMinutes)|(DateTime.IsInNextNSeconds)|(DateTime.IsInPreviousHour)|(DateTimeZone.FromFileTime)|(List.ReplaceMatchingItems)|(Table.FilterWithDataTable)|(Table.ReplaceMatchingRows)|(Table.UnpivotOtherColumns)|(AzureEnterprise.Contents)|(Date.IsInPreviousNMonths)|(Date.IsInPreviousQuarter)|(DateTime.IsInCurrentHour)|(DateTimeZone.FixedUtcNow)|(DateTimeZone.ZoneMinutes)|(GoogleAnalytics.Accounts)|(List.RemoveMatchingItems)|(Number.BitwiseShiftRight)|(Number.RoundAwayFromZero)|(SqlExpression.SchemaFrom)|(Table.ExpandRecordColumn)|(Table.RemoveMatchingRows)|(Table.ReplaceErrorValues)|(Value.ResourceExpression)|(Webtrends.ReportContents)|(ActiveDirectory.Domains)|(AmazonRedshift.Database)|(AzureDevOpsServer.Views)|(Binary.InferContentType)|(Date.IsInCurrentQuarter)|(Date.IsInPreviousNWeeks)|(Date.IsInPreviousNYears)|(DateTime.IsInNextMinute)|(DateTime.IsInNextNHours)|(DateTime.IsInNextSecond)|(DateTimeZone.RemoveZone)|(DateTimeZone.SwitchZone)|(GoogleBigQuery.Database)|(Number.BitwiseShiftLeft)|(PlanviewEnterprise.Feed)|(Splitter.SplitByNothing)|(Table.ExpandTableColumn)|(Tables.GetRelationships)|(Type.FunctionParameters)|(AzureDevOpsServer.Feed)|(AzureEnterprise.Tables)|(AzureHiveLLAP.Database)|(BinaryFormat.ByteOrder)|(BinaryFormat.Transform)|(Cube.AttributeMemberId)|(Cube.MeasureProperties)|(Cube.ReplaceDimensions)|(Date.IsInNextNQuarters)|(Date.IsInPreviousMonth)|(Date.IsInPreviousNDays)|(DateTime.FixedLocalNow)|(DateTimeZone.ZoneHours)|(Diagnostics.ActivityId)|(List.StandardDeviation)|(MarkLogicODBC.Contents)|(Number.RoundTowardZero)|(Record.TransformFields)|(Table.ExpandListColumn)|(Table.TransformColumns)|(Text.BetweenDelimiters)|(BIConnector.ContentsX)|(Cube.AddMeasureColumn)|(Date.IsInCurrentMonth)|(Date.IsInPreviousWeek)|(Date.IsInPreviousYear)|(DateTime.FromFileTime)|(DateTime.IsInNextHour)|(DateTimeZone.FromText)|(DateTimeZone.LocalNow)|(DateTimeZone.ToRecord)|(Duration.TotalMinutes)|(Duration.TotalSeconds)|(Excel.CurrentWorkbook)|(Expression.Identifier)|(Function.IsDataSource)|(Function.ScalarVector)|(Mixpanel.FunnelByName)|(Mixpanel.Segmentation)|(QubolePresto.Contents)|(Record.FieldOrDefault)|(Replacer.ReplaceValue)|(SurveyMonkey.Contents)|(Table.DuplicateColumn)|(Table.PartitionValues)|(Type.ReplaceTableKeys)|(Value.ReplaceMetadata)|(AdobeAnalytics.Cubes)|(AdoDotNet.DataSource)|(BIConnector.Contents)|(BinaryFormat.Decimal)|(Character.FromNumber)|(Comparer.FromCulture)|(Cube.MeasureProperty)|(Date.IsInCurrentWeek)|(Date.IsInCurrentYear)|(Date.IsInNextNMonths)|(Date.IsInNextQuarter)|(Date.IsInPreviousDay)|(DateTimeZone.ToLocal)|(DynamicsNav.Contents)|(Function.InvokeAfter)|(HdInsight.Containers)|(List.SingleOrDefault)|(MailChimp.Collection)|(Number.IntegerDivide)|(Number.RandomBetween)|(Record.ReorderFields)|(Replacer.ReplaceText)|(RowExpression.Column)|(Table.AddIndexColumn)|(Table.CombineColumns)|(Table.FromPartitions)|(Table.MatchesAllRows)|(Table.MatchesAnyRows)|(Table.PromoteHeaders)|(Table.ReorderColumns)|(Text.BeforeDelimiter)|(Troux.TestConnection)|(Uri.BuildQueryString)|(Uri.EscapeDataString)|(Value.NullableEquals)|(Value.RemoveMetadata)|(VSTS.AccountContents)|(Webtrends.KeyMetrics)|(AzureStorage.Tables)|(BinaryFormat.Binary)|(BinaryFormat.Choice)|(BinaryFormat.Double)|(BinaryFormat.Length)|(BinaryFormat.Record)|(BinaryFormat.Single)|(Cube.ApplyParameter)|(Cube.DisplayFolders)|(Date.IsInCurrentDay)|(Date.IsInNextNWeeks)|(Date.IsInNextNYears)|(Date.IsInYearToDate)|(Date.StartOfQuarter)|(DateTimeZone.ToText)|(DateTimeZone.UtcNow)|(DocumentDB.Contents)|(Duration.TotalHours)|(Expression.Constant)|(Expression.Evaluate)|(ItemExpression.From)|(JethroODBC.Database)|(Mixpanel.FunnelById)|(Number.Combinations)|(Number.Permutations)|(PostgreSQL.Database)|(Record.RemoveFields)|(Record.RenameFields)|(Record.SelectFields)|(SharePoint.Contents)|(Snowflake.Databases)|(Table.AddJoinColumn)|(Table.AlternateRows)|(Table.ColumnsOfType)|(Table.DemoteHeaders)|(Table.PositionOfAny)|(Table.PrefixColumns)|(Table.RemoveColumns)|(Table.RenameColumns)|(Table.SelectColumns)|(Table.TransformRows)|(TeamDesk.SelectView)|(Text.AfterDelimiter)|(Type.FunctionReturn)|(VSTS.AnalyticsViews)|(Web.BrowserContents)|(ApacheSpark.Tables)|(appFigures.Content)|(AzureStorage.Blobs)|(BinaryFormat.Group)|(Character.ToNumber)|(DataWorld.Contents)|(Date.DayOfWeekName)|(Date.IsInNextMonth)|(Date.IsInNextNDays)|(Date.QuarterOfYear)|(DateTimeZone.ToUtc)|(Duration.TotalDays)|(HdInsight.Contents)|(Kyligence.Database)|(List.DateTimeZones)|(List.PositionOfAny)|(List.TransformMany)|(MailChimp.Instance)|(MailChimp.TablesV2)|(Marketo.Activities)|(QuickBase.Contents)|(Record.FieldValues)|(RowExpression.From)|(Salesforce.Reports)|(Smartsheet.Content)|(SparkPost.GetTable)|(SparkPost.NavTable)|(Table.RemoveFirstN)|(Table.ReplaceValue)|(Table.ViewFunction)|(Text.PositionOfAny)|(Type.ReplaceFacets)|(Zendesk.Collection)|(appFigures.Tables)|(AzureSpark.Tables)|(Binary.Decompress)|(BinaryFormat.Byte)|(BinaryFormat.List)|(BinaryFormat.Null)|(BinaryFormat.Text)|(DataLake.Contents)|(DataWorld.Dataset)|(Date.EndOfQuarter)|(Date.IsInNextWeek)|(Date.IsInNextYear)|(Date.StartOfMonth)|(DateTime.FromText)|(DateTime.LocalNow)|(DateTime.ToRecord)|(DateTimeZone.From)|(Diagnostics.Trace)|(Duration.FromText)|(Duration.ToRecord)|(Exchange.Contents)|(Github.PagedTable)|(Informix.Database)|(List.NonNullCount)|(List.RemoveFirstN)|(List.ReplaceRange)|(List.ReplaceValue)|(Mixpanel.Contents)|(Number.BitwiseAnd)|(Number.BitwiseNot)|(Number.BitwiseXor)|(Odbc.InferOptions)|(PowerBI.Dataflows)|(Projectplace.Feed)|(QuickBooks.Report)|(QuickBooks.Tables)|(Record.FieldCount)|(Record.FieldNames)|(SharePoint.Tables)|(Smartsheet.Tables)|(SparkPost.GetList)|(Table.ColumnCount)|(Table.ColumnNames)|(Table.ContainsAll)|(Table.ContainsAny)|(Table.FromColumns)|(Table.FromRecords)|(Table.RemoveLastN)|(Table.ReplaceKeys)|(Table.ReplaceRows)|(Table.ReverseRows)|(Table.SplitColumn)|(TeamDesk.Database)|(Teradata.Database)|(Text.ReplaceRange)|(Type.ClosedRecord)|(Type.IsOpenRecord)|(Type.RecordFields)|(Value.NativeQuery)|(Value.ReplaceType)|(WebAction.Request)|(Webtrends.Profile)|(Comparer.Ordinal)|(Cube.PropertyKey)|(Date.AddQuarters)|(Date.DaysInMonth)|(Date.IsInNextDay)|(Date.StartOfWeek)|(Date.StartOfYear)|(Date.WeekOfMonth)|(DateTime.AddZone)|(Dremio.Databases)|(Duration.Minutes)|(Duration.Seconds)|(Lines.FromBinary)|(List.ContainsAll)|(List.ContainsAny)|(List.InsertRange)|(List.RemoveItems)|(List.RemoveLastN)|(List.RemoveNulls)|(List.RemoveRange)|(Logical.FromText)|(MailChimp.Tables)|(Mixpanel.Funnels)|(Netezza.Database)|(Number.BitwiseOr)|(Number.Factorial)|(Number.RoundDown)|(OleDb.DataSource)|(QuickBooks.Query)|(RData.FromBinary)|(Record.FromTable)|(Record.HasFields)|(SapHana.Database)|(SharePoint.Files)|(Smartsheet.Query)|(SweetIQ.Contents)|(Table.FirstValue)|(Table.HasColumns)|(Table.InsertRows)|(Table.IsDistinct)|(Table.NestedJoin)|(Table.PositionOf)|(Table.RemoveRows)|(Table.SelectRows)|(Text.RemoveRange)|(Time.StartOfHour)|(Troux.CustomFeed)|(tyGraph.NavTable)|(Type.AddTableKey)|(Type.ForFunction)|(Type.NonNullable)|(Type.TableColumn)|(Type.TableSchema)|(Vertica.Database)|(Webtrends.Tables)|(Access.Database)|(AdoDotNet.Query)|(Binary.Compress)|(Binary.FromList)|(Binary.FromText)|(Comparer.Equals)|(Cube.Dimensions)|(Cube.Parameters)|(Cube.Properties)|(Date.EndOfMonth)|(Date.IsLeapYear)|(Date.StartOfDay)|(Date.WeekOfYear)|(DateTime.ToText)|(Denodo.Contents)|(Duration.ToText)|(Exasol.Database)|(Folder.Contents)|(Function.Invoke)|(Github.Contents)|(HdInsight.Files)|(Impala.Database)|(Kusto.Databases)|(List.Accumulate)|(List.Covariance)|(List.Difference)|(List.IsDistinct)|(List.MatchesAll)|(List.MatchesAny)|(List.PositionOf)|(Mixpanel.Export)|(Mixpanel.Tables)|(Number.FromText)|(Odbc.DataSource)|(Oracle.Database)|(Paxata.Contents)|(Percentage.From)|(Record.AddField)|(Record.FromList)|(Resource.Access)|(Salesforce.Data)|(Stripe.Contents)|(Sybase.Database)|(Table.AddColumn)|(Table.FromValue)|(Table.Partition)|(Table.SingleRow)|(Table.ToColumns)|(Table.ToRecords)|(Table.Transpose)|(TeamDesk.Select)|(Text.FromBinary)|(Text.PositionOf)|(Text.StartsWith)|(Twilio.Contents)|(Type.IsNullable)|(Type.OpenRecord)|(Binary.Combine)|(Cube.Transform)|(DataLake.Files)|(Date.AddMonths)|(Date.DayOfWeek)|(Date.DayOfYear)|(Date.EndOfWeek)|(Date.EndOfYear)|(Date.MonthName)|(Duration.Hours)|(Embedded.Value)|(Emigo.Contents)|(Excel.Workbook)|(Facebook.Graph)|(Json.FromValue)|(Kusto.Contents)|(Lines.FromText)|(Lines.ToBinary)|(List.Alternate)|(List.DateTimes)|(List.Durations)|(List.Intersect)|(List.Positions)|(List.Transform)|(Logical.ToText)|(Marketo.Tables)|(MySQL.Database)|(Number.RoundUp)|(Python.Execute)|(Record.Combine)|(Record.ToTable)|(SweetIQ.Tables)|(Table.Contains)|(Table.Distinct)|(Table.FillDown)|(Table.FindText)|(Table.FromList)|(Table.FromRows)|(Table.RowCount)|(Text.TrimStart)|(Time.EndOfHour)|(Type.ForRecord)|(Type.TableKeys)|(Value.Firewall)|(Value.FromText)|(Value.Metadata)|(Value.Multiply)|(Value.Subtract)|(Variable.Value)|(Zendesk.Tables)|(AtScale.Cubes)|(Binary.Buffer)|(Binary.Length)|(Binary.ToList)|(Binary.ToText)|(Cube.Measures)|(Currency.From)|(Date.AddWeeks)|(Date.AddYears)|(Date.EndOfDay)|(Date.FromText)|(Date.ToRecord)|(DateTime.Date)|(DateTime.From)|(DateTime.Time)|(Duration.Days)|(Duration.From)|(Essbase.Cubes)|(File.Contents)|(Function.From)|(Github.Tables)|(Hdfs.Contents)|(Json.Document)|(List.Contains)|(List.Distinct)|(List.FindText)|(List.Generate)|(Marketo.Leads)|(Number.IsEven)|(Number.Random)|(Number.ToText)|(Record.ToList)|(Sql.Databases)|(Stripe.Method)|(Stripe.Tables)|(Table.Combine)|(Table.IsEmpty)|(Table.Profile)|(Table.Unpivot)|(Text.Contains)|(Text.EndsWith)|(Text.PadStart)|(Text.SplitAny)|(Text.ToBinary)|(Time.FromText)|(Time.ToRecord)|(Twilio.Tables)|(Type.ListItem)|(Type.TableRow)|(Value.Compare)|(VSTS.Contents)|(Cds.Contents)|(Cds.Entities)|(Csv.Document)|(Date.AddDays)|(DB2.Database)|(Decimal.From)|(Error.Record)|(Folder.Files)|(Lines.ToText)|(List.AllTrue)|(List.AnyTrue)|(List.Average)|(List.Combine)|(List.IsEmpty)|(List.Numbers)|(List.Product)|(List.Reverse)|(Logical.From)|(Number.Atan2)|(Number.IsNaN)|(Number.IsOdd)|(Number.Log10)|(Number.Power)|(Number.Round)|(Record.Field)|(Spark.Tables)|(Sql.Database)|(Table.AddKey)|(Table.Buffer)|(Table.Column)|(Table.FillUp)|(Table.FirstN)|(Table.Repeat)|(Table.Schema)|(Table.ToList)|(Table.ToRows)|(Text.Combine)|(Text.NewGuid)|(Text.Replace)|(Text.Reverse)|(Text.TrimEnd)|(tyGraph.Feed)|(Value.Divide)|(Value.Equals)|(Web.Contents)|(Xml.Document)|(Binary.From)|(Date.ToText)|(Double.From)|(List.Buffer)|(List.FirstN)|(List.Median)|(List.Random)|(List.Repeat)|(List.Select)|(List.Single)|(Number.Acos)|(Number.Asin)|(Number.Atan)|(Number.Cosh)|(Number.From)|(Number.Sign)|(Number.Sinh)|(Number.Sqrt)|(Number.Tanh)|(OleDb.Query)|(Single.From)|(Table.First)|(Table.Group)|(Table.LastN)|(Table.Pivot)|(Table.Range)|(Table.Split)|(Text.Format)|(Text.Insert)|(Text.Length)|(Text.Middle)|(Text.PadEnd)|(Text.Proper)|(Text.Remove)|(Text.Repeat)|(Text.Select)|(Text.ToList)|(Time.Minute)|(Time.Second)|(Time.ToText)|(Type.Facets)|(Uri.Combine)|(Date.Month)|(Hdfs.Files)|(Html.Table)|(Int16.From)|(Int32.From)|(Int64.From)|(List.Count)|(List.Dates)|(List.First)|(List.LastN)|(List.Modes)|(List.Range)|(List.Split)|(List.Times)|(List.Union)|(Number.Abs)|(Number.Cos)|(Number.Exp)|(Number.Log)|(Number.Mod)|(Number.Sin)|(Number.Tan)|(OData.Feed)|(Odbc.Query)|(Table.Join)|(Table.Keys)|(Table.Last)|(Table.MaxN)|(Table.MinN)|(Table.Skip)|(Table.Sort)|(Table.View)|(Text.Clean)|(Text.Lower)|(Text.Range)|(Text.Split)|(Text.Start)|(Text.Upper)|(Troux.Feed)|(Twilio.URL)|(Type.Union)|(Value.Type)|(VSTS.Views)|(Xml.Tables)|(Byte.From)|(Date.From)|(Date.Year)|(Guid.From)|(Int8.From)|(List.Last)|(List.MaxN)|(List.MinN)|(List.Mode)|(List.Skip)|(List.Sort)|(Number.Ln)|(R.Execute)|(Soda.Feed)|(Table.Max)|(Table.Min)|(Text.From)|(Text.Trim)|(Time.From)|(Time.Hour)|(Uri.Parts)|(Value.Add)|(VSTS.Feed)|(Date.Day)|(List.Max)|(List.Min)|(List.Sum)|(List.Zip)|(Text.End)|(Value.As)|(Value.Is)|(Web.Page)|(Text.At)|(Type.Is))\\b"
-				},
-				{
-					"name": "entity.support.type.powerquery",
-					"match": "\\b((SapBusinessWarehouseExecutionMode.Type)|(SapHanaRangeOperator.Type)|(SapHanaDistribution.Type)|(BinaryOccurrence.Type)|(RelativePosition.Type)|(LimitClauseKind.Type)|(BinaryEncoding.Type)|(JoinAlgorithm.Type)|(SparkProtocol.Type)|(DateTimeZone.Type)|(MissingField.Type)|(RoundingMode.Type)|(TextEncoding.Type)|(Compression.Type)|(ExtraValues.Type)|(Occurrence.Type)|(Percentage.Type)|(QuoteStyle.Type)|(TraceLevel.Type)|(Culture.Current)|(ByteOrder.Type)|(Character.Type)|(GroupKind.Type)|(Precision.Type)|(WebMethod.Type)|(CsvStyle.Type)|(Currency.Type)|(DateTime.Type)|(Duration.Type)|(Function.Type)|(JoinKind.Type)|(JoinSide.Type)|(Password.Type)|(Decimal.Type)|(Logical.Type)|(Binary.Type)|(Double.Type)|(Number.Type)|(Record.Type)|(Single.Type)|(Int16.Type)|(Int32.Type)|(Int64.Type)|(Order.Type)|(Table.Type)|(Byte.Type)|(Date.Type)|(Guid.Type)|(Int8.Type)|(List.Type)|(None.Type)|(Null.Type)|(Text.Type)|(Time.Type)|(Type.Type)|(Any.Type)|(Day.Type)|(Uri.Type))\\b"
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.control.powerquery",
-					"match": "\\b((otherwise)|(error)|(each)|(else)|(then)|(let)|(try)|(if)|(in))\\b"
-				},
-				{
-					"name": "keyword.constant.language.powerquery",
-					"match": "\\b((false)|(true))\\b"
-				},
-				{
-					"name": "keyword.operator.powerquery",
-					"match": "\\b((and)|(not)|(as)|(is)|(or))\\b"
-				},
-				{
-					"name": "keyword.other.powerquery",
-					"match": "\\b((datetimezone)|(datetime)|(duration)|(infinity)|(sections)|(section)|(shared)|(binary)|(shared)|(table)|(meta)|(type)|(time)|(nan))\\b"
-				},
-				{
-					"name": "keyword.other.powerquery2",
-					"match": "\\b#date\\b"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.powerquery",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.powerquery",
-					"match": "\\\\."
-				}
-			]
-		}
-	},
-	"scopeName": "text.powerquery"
+  "name": "powerquery",
+  "scopeName": "source.powerquery",
+  "fileTypes": ["pq", "pqm"],
+  "uuid": "41968B57-12E6-4AC5-92A4-A837010E8B0A",
+  "patterns": [
+    {
+      "include": "#Noise"
+    },
+    {
+      "include": "#LiteralExpression"
+    },
+    {
+      "include": "#Keywords"
+    },
+    {
+      "include": "#ImplicitVariable"
+    },
+    {
+      "include": "#IntrinsicVariable"
+    },
+    {
+      "include": "#Operators"
+    },
+    {
+      "include": "#DotOperators"
+    },
+    {
+      "include": "#TypeName"
+    },
+    {
+      "include": "#RecordExpression"
+    },
+    {
+      "include": "#Punctuation"
+    },
+    {
+      "include": "#QuotedIdentifier"
+    },
+    {
+      "include": "#Identifier"
+    }
+  ],
+  "repository": {
+    "Keywords": {
+      "match": "\\b(?:(and|or|not)|(if|then|else)|(try|otherwise)|(as|each|in|is|let|meta|type|error)|(section|shared))\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.word.logical.powerquery"
+        },
+        "2": {
+          "name": "keyword.control.conditional.powerquery"
+        },
+        "3": {
+          "name": "keyword.control.exception.powerquery"
+        },
+        "4": {
+          "name": "keyword.other.powerquery"
+        },
+        "5": {
+          "name": "keyword.powerquery"
+        }
+      }
+    },
+    "TypeName": {
+      "match": "\\b(?:(optional|nullable)|(action|any|anynonnull|binary|date|datetime|datetimezone|duration|function|list|logical|none|null|number|record|table|text|type))\\b",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.powerquery"
+        },
+        "2": {
+          "name": "storage.type.powerquery"
+        }
+      }
+    },
+    "LiteralExpression": {
+      "patterns": [
+        {
+          "include": "#String"
+        },
+        {
+          "include": "#NumericConstant"
+        },
+        {
+          "include": "#LogicalConstant"
+        },
+        {
+          "include": "#NullConstant"
+        },
+        {
+          "include": "#FloatNumber"
+        },
+        {
+          "include": "#DecimalNumber"
+        },
+        {
+          "include": "#HexNumber"
+        },
+        {
+          "include": "#IntNumber"
+        }
+      ]
+    },
+    "Noise": {
+      "patterns": [
+        {
+          "include": "#BlockComment"
+        },
+        {
+          "include": "#LineComment"
+        },
+        {
+          "include": "#Whitespace"
+        }
+      ]
+    },
+    "Whitespace": {
+      "match": "\\s+"
+    },
+    "BlockComment": {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.block.powerquery"
+    },
+    "LineComment": {
+      "match": "//.*",
+      "name": "comment.line.double-slash.powerquery"
+    },
+    "String": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.powerquery"
+        }
+      },
+      "end": "\"(?!\")",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.powerquery"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\"\"",
+          "name": "constant.character.escape.quote.powerquery"
+        },
+        {
+          "include": "#EscapeSequence"
+        }
+      ],
+      "name": "string.quoted.double.powerquery"
+    },
+    "QuotedIdentifier": {
+      "begin": "#\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.quotedidentifier.begin.powerquery"
+        }
+      },
+      "end": "\"(?!\")",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.quotedidentifier.end.powerquery"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\"\"",
+          "name": "constant.character.escape.quote.powerquery"
+        },
+        {
+          "include": "#EscapeSequence"
+        }
+      ],
+      "name": "entity.name.powerquery"
+    },
+    "EscapeSequence": {
+      "begin": "#\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.escapesequence.begin.powerquery"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.escapesequence.end.powerquery"
+        }
+      },
+      "patterns": [
+        {
+          "match": "(#|\\h{4}|\\h{8}|cr|lf|tab)(?:,(#|\\h{4}|\\h{8}|cr|lf|tab))*"
+        },
+        {
+          "match": "[^\\)]",
+          "name": "invalid.illegal.escapesequence.powerquery"
+        }
+      ],
+      "name": "constant.character.escapesequence.powerquery"
+    },
+    "LogicalConstant": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.logical.powerquery"
+    },
+    "NullConstant": {
+      "match": "\\b(null)\\b",
+      "name": "constant.language.null.powerquery"
+    },
+    "NumericConstant": {
+      "match": "(?<![\\d\\w])(#infinity|#nan)\\b",
+      "captures": {
+        "1": {
+          "name": "constant.language.numeric.float.powerquery"
+        }
+      }
+    },
+    "HexNumber": {
+      "match": "0(x|X)\\h+",
+      "name": "constant.numeric.integer.hexadecimal.powerquery"
+    },
+    "IntNumber": {
+      "match": "\\b(\\d+)\\b",
+      "captures": {
+        "1": {
+          "name": "constant.numeric.integer.powerquery"
+        }
+      }
+    },
+    "DecimalNumber": {
+      "match": "(?<![\\d\\w])(\\d*\\.\\d+)\\b",
+      "name": "constant.numeric.decimal.powerquery"
+    },
+    "FloatNumber": {
+      "match": "(\\d*\\.)?\\d+(e|E)(\\+|-)?\\d+",
+      "name": "constant.numeric.float.powerquery"
+    },
+    "InclusiveIdentifier": {
+      "match": "@",
+      "captures": {
+        "0": {
+          "name": "inclusiveidentifier.powerquery"
+        }
+      }
+    },
+    "Identifier": {
+      "match": "(?x:(?<![\\._\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}\\p{Nd}\\p{Pc}\\p{Mn}\\p{Mc}\\p{Cf}])(@?)([_\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}][_\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}\\p{Nd}\\p{Pc}\\p{Mn}\\p{Mc}\\p{Cf}]*(?:\\.[_\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}][_\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}\\p{Nd}\\p{Pc}\\p{Mn}\\p{Mc}\\p{Cf}])*)\\b)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.inclusiveidentifier.powerquery"
+        },
+        "2": {
+          "name": "entity.name.powerquery"
+        }
+      }
+    },
+    "Operators": {
+      "match": "(=>)|(=)|(<>|<|>|<=|>=)|(&)|(\\+|-|\\*|\\/)|(!)|(\\?)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.function.powerquery"
+        },
+        "2": {
+          "name": "keyword.operator.assignment-or-comparison.powerquery"
+        },
+        "3": {
+          "name": "keyword.operator.comparison.powerquery"
+        },
+        "4": {
+          "name": "keyword.operator.combination.powerquery"
+        },
+        "5": {
+          "name": "keyword.operator.arithmetic.powerquery"
+        },
+        "6": {
+          "name": "keyword.operator.sectionaccess.powerquery"
+        },
+        "7": {
+          "name": "keyword.operator.optional.powerquery"
+        }
+      }
+    },
+    "DotOperators": {
+      "match": "(?<!\\.)(?:(\\.\\.\\.)|(\\.\\.))(?!\\.)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.ellipsis.powerquery"
+        },
+        "2": {
+          "name": "keyword.operator.list.powerquery"
+        }
+      }
+    },
+    "RecordExpression": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.begin.powerquery"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.end.powerquery"
+        }
+      },
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ],
+      "contentName": "meta.recordexpression.powerquery"
+    },
+    "Punctuation": {
+      "match": "(,)|(\\()|(\\))|({)|(})",
+      "captures": {
+        "1": {
+          "name": "punctuation.separator.powerquery"
+        },
+        "2": {
+          "name": "punctuation.section.parens.begin.powerquery"
+        },
+        "3": {
+          "name": "punctuation.section.parens.end.powerquery"
+        },
+        "4": {
+          "name": "punctuation.section.braces.begin.powerquery"
+        },
+        "5": {
+          "name": "punctuation.section.braces.end.powerquery"
+        }
+      }
+    },
+    "ImplicitVariable": {
+      "match": "\\b_\\b",
+      "name": "keyword.operator.implicitvariable.powerquery"
+    },
+    "IntrinsicVariable": {
+      "match": "(?<![\\d\\w])(#sections|#shared)\\b",
+      "captures": {
+        "1": {
+          "name": "constant.language.intrinsicvariable.powerquery"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Copied grammar from [powerquery-language](https://github.com/Microsoft/powerquery-language), which improves overall accuracy. Still have a number of outstanding issues with it that we'll continue to iterate on.

JSON files were reformatted with Prettier. 

Moved to 0.0.10 of powerquery-parser. 