### PR TITLE
Improve LogicalExpression formatting

### DIFF
--- a/packages/format/src/format/passes/isMultiline/isMultilineFirstPass.ts
+++ b/packages/format/src/format/passes/isMultiline/isMultilineFirstPass.ts
@@ -70,11 +70,20 @@ function visitNode(state: State, node: Ast.TNode): void {
         case Ast.NodeKind.EqualityExpression:
         case Ast.NodeKind.LogicalExpression:
         case Ast.NodeKind.RelationalExpression: {
+            const left: Ast.TNode = node.left;
+            const right: Ast.TNode = node.right;
+
+            if (
+                (Ast.isTBinOpExpression(left) && containsLogicalExpression(left)) ||
+                (Ast.isTBinOpExpression(right) && containsLogicalExpression(right))
+            ) {
+                isMultiline = true;
+            }
             const linearLength: number = getLinearLength(state.linearLengthMap, state.nodeIdMapCollection, node);
             if (linearLength > TBinOpExpressionLinearLengthThreshold) {
                 isMultiline = true;
             } else {
-                isMultiline = isAnyMultiline(isMultilineMap, node.left, node.operatorConstant, node.right);
+                isMultiline = isAnyMultiline(isMultilineMap, left, node.operatorConstant, right);
             }
 
             break;
@@ -418,4 +427,18 @@ function containsNewline(text: string): boolean {
         }
     }
     return false;
+}
+
+function containsLogicalExpression(node: Ast.TBinOpExpression): boolean {
+    if (!Ast.isTBinOpExpression(node)) {
+        return false;
+    }
+    const left: Ast.TNode = node.left;
+    const right: Ast.TNode = node.right;
+
+    return (
+        node.kind === Ast.NodeKind.LogicalExpression ||
+        (Ast.isTBinOpExpression(left) && containsLogicalExpression(left)) ||
+        (Ast.isTBinOpExpression(right) && containsLogicalExpression(right))
+    );
 }

--- a/packages/format/src/format/passes/serializerParameter.ts
+++ b/packages/format/src/format/passes/serializerParameter.ts
@@ -139,11 +139,12 @@ function visitNode(state: State, node: Ast.TNode): void {
         case Ast.NodeKind.LogicalExpression:
         case Ast.NodeKind.RelationalExpression: {
             propagateWriteKind(state, node, node.left);
+            const isMultiline: boolean = expectGetIsMultiline(state.isMultilineMap, node);
 
-            if (expectGetIsMultiline(state.isMultilineMap, node)) {
+            if (isMultiline) {
                 setWorkspace(state, node.operatorConstant, { maybeWriteKind: SerializerWriteKind.Indented });
                 setWorkspace(state, node.right, { maybeWriteKind: SerializerWriteKind.PaddedLeft });
-            } else if (node.kind === Ast.NodeKind.LogicalExpression) {
+            } else if (node.kind === Ast.NodeKind.LogicalExpression && isMultiline) {
                 setWorkspace(state, node.operatorConstant, { maybeWriteKind: SerializerWriteKind.PaddedLeft });
                 setWorkspace(state, node.right, { maybeWriteKind: SerializerWriteKind.Indented });
             } else {

--- a/packages/format/src/test/serializer/simple.ts
+++ b/packages/format/src/test/serializer/simple.ts
@@ -969,22 +969,76 @@ aReallyReallyReallyReallyLongIdentifier
             compare(expected, actual);
         });
 
-        it(`true or false and true or true`, () => {
+        it(`let x = true and true`, () => {
             const expected: string = `
-true or
-false and
-true or
-true`;
+let
+    x = true and true
+in
+    x`;
+            const actual: string = runFormat(`let x = true and true in x`);
+            compare(expected, actual);
+        });
+
+        it(`let x = 1 <> 2 and 3 <> 4 in x`, () => {
+            const expected: string = `
+let
+    x = 1 <> 2 and 3 <> 4
+in
+    x`;
+            const actual: string = runFormat(`let x = 1 <> 2 and 3 <> 4 in x`);
+            compare(expected, actual);
+        });
+
+        it(`true or false and true or true`, () => {
+            const expected: string = `true or false and true or true`;
             const actual: string = runFormat(`true or false and true or true`);
             compare(expected, actual);
         });
 
         it(`a = true and b = true and c = true`, () => {
-            const expected: string = `
-a = true and
-b = true and
-c = true`;
+            const expected: string = `a = true and b = true and c = true`;
             const actual: string = runFormat(`a = true and b = true and c = true`);
+            compare(expected, actual);
+        });
+
+        it(`true and true and (if true then true else false)`, () => {
+            const expected: string = `
+true
+and true
+and (
+    if true then
+        true
+    else
+        false
+)`;
+            const actual: string = runFormat(`true and true and (if true then true else false)`);
+            compare(expected, actual);
+        });
+
+        it(`true and (if true then true else false) and true`, () => {
+            const expected: string = `
+true
+and (
+    if true then
+        true
+    else
+        false
+)
+and true`;
+            const actual: string = runFormat(`true and (if true then true else false) and true`);
+            compare(expected, actual);
+        });
+
+        it(`(if true then true else false) and true`, () => {
+            const expected: string = `
+(
+    if true then
+        true
+    else
+        false
+)
+and true`;
+            const actual: string = runFormat(`(if true then true else false) and true`);
             compare(expected, actual);
         });
     });


### PR DESCRIPTION
There was an inconsistency where serializerParameter was making LogicalExpression be multiline while isMultiline was false. This was corrected, along with what should be improved formatting logic, and additional tests.