### PR TITLE
Improve word break logic

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,30 +1,28 @@
 {
-    "comments": {
-        // symbol used for single line comment
-        "lineComment": "//",
-        // symbols used for start and end a block comment
-        "blockComment": [ "/*", "*/" ]
-    },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
-    // symbols that are auto closed when typing
-    "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ],
-    // symbols that that can be used to surround a selection
-    "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ]
+  "comments": {
+    // symbol used for single line comment
+    "lineComment": "//",
+    // symbols used for start and end a block comment
+    "blockComment": ["/*", "*/"]
+  },
+  // symbols used as brackets
+  "brackets": [["{", "}"], ["[", "]"], ["(", ")"]],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // (built-in identifier)|(quoted identifier)|(each record field)|(number.float)|(number.hex)|(number)|(identifier)
+  "wordPattern": "(#\\w+)|(#\".+?\")|(_?\\[\\w+\\])|(-?\\d*\\.\\d+(?:[eE][\\-+]?\\d+)?)|(-?0[xX][0-9a-fA-F]+)|(-?\\d+(?:[eE][\\-+]?\\d+)?)|([^\\[\\]\\`\\~\\!\\@\\%\\^\\&\\*\\(\\)\\-\\=\\+\\{\\}\\\\\\|\\;\\:\\'\\\"\\,\\<\\>\\/\\?\\s]+)"
 }


### PR DESCRIPTION
Define explicit word break patterns to override the monaco defaults. This resolves issue #28. 