### PR TITLE
[v0.1.2] Support for Outline, improved Diagnostics, and Locale configuration setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-    "recommendations": ["eamodio.tsl-problem-matcher"],
+    "recommendations": ["eamodio.tsl-problem-matcher", "esbenp.prettier-vscode"],
     "unwantedRecommendations": []
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,6 +30,12 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@types/chai": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+            "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+            "dev": true
+        },
         "@types/glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
         "vscode-languageclient": "6.1.3"
     },
     "devDependencies": {
+        "@types/chai": "4.2.11",
         "@types/glob": "7.1.2",
         "@types/mocha": "7.0.2",
         "@types/node": "14.0.13",

--- a/client/src/test/suite/completionUtils.ts
+++ b/client/src/test/suite/completionUtils.ts
@@ -21,7 +21,6 @@ export async function testCompletion(
     expectedCompletionList: vscode.CompletionList,
     vertification: VertificationType,
 ): Promise<void> {
-    // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
     const actualCompletionList: vscode.CompletionList | undefined = await testCompletionBase(docUri, position);
     if (actualCompletionList === undefined) {
         throw new Error("CompletionList is undefined");

--- a/client/src/test/suite/completionUtils.ts
+++ b/client/src/test/suite/completionUtils.ts
@@ -7,6 +7,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 
 import * as TestUtils from "./testUtils";
+import { Commands } from "./testUtils";
 
 export enum VertificationType {
     Exact,
@@ -64,5 +65,5 @@ async function testCompletionBase(
     await TestUtils.activate(docUri);
 
     // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
-    return vscode.commands.executeCommand("vscode.executeCompletionItemProvider", docUri, position);
+    return vscode.commands.executeCommand(Commands.CompletionItems, docUri, position);
 }

--- a/client/src/test/suite/documentSymbolUtils.ts
+++ b/client/src/test/suite/documentSymbolUtils.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable: no-implicit-dependencies
+
+import { assert, expect } from "chai";
+import * as vscode from "vscode";
+
+import * as TestUtils from "./testUtils";
+import { Commands } from "./testUtils";
+
+export interface ExpectedDocumentSymbol {
+    name: string;
+    kind: vscode.SymbolKind;
+    children?: ExpectedDocumentSymbol[];
+}
+
+export async function testDocumentSymbols(
+    docUri: vscode.Uri,
+    expectedSymbols: ExpectedDocumentSymbol[],
+): Promise<void> {
+    const documentSymbols: vscode.DocumentSymbol[] | undefined = await documentSymbolsBase(docUri);
+    if (documentSymbols === undefined) {
+        assert.fail("documentSymbols undefined");
+    }
+
+    const actualSymbols: ExpectedDocumentSymbol[] = documentSymbolArrayToExpectedSymbols(documentSymbols);
+    expect(actualSymbols).deep.equals(expectedSymbols, "Expected document symbols to match.");
+}
+
+async function documentSymbolsBase(docUri: vscode.Uri): Promise<vscode.DocumentSymbol[] | undefined> {
+    await TestUtils.activate(docUri);
+
+    return vscode.commands.executeCommand(Commands.DocumentSymbols, docUri);
+}
+
+function documentSymbolArrayToExpectedSymbols(documentSymbols: vscode.DocumentSymbol[]): ExpectedDocumentSymbol[] {
+    const expectedSymbols: ExpectedDocumentSymbol[] = [];
+    documentSymbols.forEach(element => {
+        let children: ExpectedDocumentSymbol[] | undefined;
+        if (element.children && element.children.length > 0) {
+            children = documentSymbolArrayToExpectedSymbols(element.children);
+            expectedSymbols.push({ name: element.name, kind: element.kind, children });
+        } else {
+            expectedSymbols.push({ name: element.name, kind: element.kind });
+        }
+    });
+    return expectedSymbols;
+}

--- a/client/src/test/suite/documentSymbols.test.ts
+++ b/client/src/test/suite/documentSymbols.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// tslint:disable: no-implicit-dependencies
+import * as vscode from "vscode";
+
+import * as DocumentSymbolUtils from "./documentSymbolUtils";
+import * as TestUtils from "./testUtils";
+
+// TODO: match completionUtils
+
+suite("DocumentSymbols", () => {
+    test("section.pq", async () => {
+        const docUri: vscode.Uri = TestUtils.getDocUri("section.pq");
+        vscode.window.showInformationMessage(`Starting tests using based file: ${docUri}`);
+
+        DocumentSymbolUtils.testDocumentSymbols(docUri, [
+            { name: "sectionTest", kind: vscode.SymbolKind.Module },
+            { name: "firstMember", kind: vscode.SymbolKind.Number },
+            { name: "secondMember", kind: vscode.SymbolKind.String },
+            { name: "thirdMember", kind: vscode.SymbolKind.Function },
+            {
+                name: "letMember",
+                kind: vscode.SymbolKind.Variable,
+                children: [
+                    { name: "a", kind: vscode.SymbolKind.Number },
+                    { name: "b", kind: vscode.SymbolKind.Number },
+                    { name: "c", kind: vscode.SymbolKind.Number },
+                ],
+            },
+        ]);
+    });
+});

--- a/client/src/test/suite/documentSymbols.test.ts
+++ b/client/src/test/suite/documentSymbols.test.ts
@@ -7,8 +7,6 @@ import * as vscode from "vscode";
 import * as DocumentSymbolUtils from "./documentSymbolUtils";
 import * as TestUtils from "./testUtils";
 
-// TODO: match completionUtils
-
 suite("DocumentSymbols", () => {
     test("section.pq", async () => {
         const docUri: vscode.Uri = TestUtils.getDocUri("section.pq");

--- a/client/src/test/suite/testUtils.ts
+++ b/client/src/test/suite/testUtils.ts
@@ -41,3 +41,11 @@ export async function setTestContent(content: string): Promise<boolean> {
     const all: vscode.Range = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
     return editor.edit(eb => eb.replace(all, content));
 }
+
+export enum Commands {
+    CompletionItems = "vscode.executeCompletionItemProvider",
+    DocumentSymbols = "vscode.executeDocumentSymbolProvider",
+    Format = "vscode.executeFormatDocumentProvider",
+    Hover = "vscode.executeHoverProvider",
+    SignatureHelp = "vscode.executeSignatureHelpProvider ",
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-powerquery",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Power Query configuration",
+            "title": "Power Query",
             "properties": {
                 "powerquery.trace.server": {
                     "scope": "window",
@@ -58,6 +58,56 @@
                     ],
                     "default": "off",
                     "description": "Traces the communication between VS Code and the language server."
+                },
+                "powerquery.general.locale": {
+                    "scope": "window",
+                    "type": "string",
+                    "description": "Locale to use for errors and other messages returned by the language parser.",
+                    "enum": [
+                        "bg-BG",
+                        "ca-EZ",
+                        "cs-CZ",
+                        "da-DK",
+                        "de-DE",
+                        "el-GR",
+                        "en-US",
+                        "es-ES",
+                        "et-EE",
+                        "eu-ES",
+                        "fi-FI",
+                        "fr-FR",
+                        "gl-ES",
+                        "hi-IN",
+                        "hr-HR",
+                        "hu-HU",
+                        "id-ID",
+                        "it-IT",
+                        "ja-JP",
+                        "kk-KZ",
+                        "ko-KR",
+                        "lt-LT",
+                        "lv-LV",
+                        "ms-MY",
+                        "nb-NO",
+                        "nl-NL",
+                        "pl-PL",
+                        "pt-BR",
+                        "pt-PT",
+                        "ro-RO",
+                        "ru-RU",
+                        "sk-SK",
+                        "sl-SI",
+                        "sr-Cyrl-RS",
+                        "sr-Latn-RS",
+                        "sv-SE",
+                        "th-TH",
+                        "tr-TR",
+                        "uk-UA",
+                        "vi-VN",
+                        "zh-CN",
+                        "zh-TW"
+                    ],
+                    "default": "en-US"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,31 +30,46 @@
                 "js-tokens": "^4.0.0"
             }
         },
-        "@microsoft/powerquery-formatter": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.6.tgz",
-            "integrity": "sha512-MyKsQRJ9LiZ5X40yRY5tch0/lxjbwpj8iSHq0ZCuDVRtuMmCAkDMawYKBlrhsfUkUXt980fUALPAq+LlOZ+E+w==",
-            "requires": {
-                "@microsoft/powerquery-parser": "0.1.56"
-            }
-        },
         "@microsoft/powerquery-language-services": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.1.9.tgz",
-            "integrity": "sha512-EdNh4X8RZvnEvTpMPYkCmWeIt+IVAmWJWC2UnBnjzfqamFZ5r3q1Eh8rFahPUx5FH4Hr2W0ZvZBzWASzySdrrA==",
+            "version": "file:../../../../temp/powerquery-language-services/package",
             "requires": {
                 "@microsoft/powerquery-formatter": "0.0.6",
                 "@microsoft/powerquery-parser": "0.1.56",
                 "vscode-languageserver-textdocument": "1.0.1",
                 "vscode-languageserver-types": "3.15.1"
-            }
-        },
-        "@microsoft/powerquery-parser": {
-            "version": "0.1.56",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.1.56.tgz",
-            "integrity": "sha512-daRR/3B772y9K8WxIJwTXmQTTXHmUAsFaMOGgo4RQ+gJywsiWTaWtCL/zqyBvpKphJK7k8BycznYdVbFIoNgvw==",
-            "requires": {
-                "grapheme-splitter": "^1.0.4"
+            },
+            "dependencies": {
+                "@microsoft/powerquery-formatter": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.0.6.tgz",
+                    "integrity": "sha512-MyKsQRJ9LiZ5X40yRY5tch0/lxjbwpj8iSHq0ZCuDVRtuMmCAkDMawYKBlrhsfUkUXt980fUALPAq+LlOZ+E+w==",
+                    "requires": {
+                        "@microsoft/powerquery-parser": "0.1.56"
+                    }
+                },
+                "@microsoft/powerquery-parser": {
+                    "version": "0.1.56",
+                    "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.1.56.tgz",
+                    "integrity": "sha512-daRR/3B772y9K8WxIJwTXmQTTXHmUAsFaMOGgo4RQ+gJywsiWTaWtCL/zqyBvpKphJK7k8BycznYdVbFIoNgvw==",
+                    "requires": {
+                        "grapheme-splitter": "^1.0.4"
+                    }
+                },
+                "grapheme-splitter": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+                    "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+                },
+                "vscode-languageserver-textdocument": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+                    "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.15.1",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+                    "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+                }
             }
         },
         "@types/chai": {
@@ -1897,11 +1912,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
-        },
-        "grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
         },
         "growl": {
             "version": "1.10.5",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
         "node": "*"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "file:D:/temp/powerquery-language-services/package",
+        "@microsoft/powerquery-language-services": "0.1.11",
         "vscode-languageserver": "6.1.1",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
         "node": "*"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "0.1.9",
+        "@microsoft/powerquery-language-services": "file:D:/temp/powerquery-language-services/package",
         "vscode-languageserver": "6.1.1",
         "vscode-languageserver-textdocument": "1.0.1",
         "vscode-languageserver-types": "3.15.1"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,6 +39,7 @@ connection.onInitialized(() => {
         analysisOptions = {
             locale: config?.general?.locale,
             librarySymbolProvider: Library.createLibraryProvider(),
+            maintainWorkspaceCache: true,
         };
     });
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,6 +25,9 @@ connection.onInitialize(() => {
                 // TODO: is it better to return the first pass without documention to reduce message size?
                 resolveProvider: false,
             },
+            documentSymbolProvider: {
+                workDoneProgress: false,
+            },
             hoverProvider: true,
             signatureHelpProvider: {
                 triggerCharacters: ["(", ","],
@@ -121,6 +124,20 @@ connection.onCompletion(
         }
 
         return [];
+    },
+);
+
+connection.onDocumentSymbol(
+    async (
+        documentSymbolParams: LS.DocumentSymbolParams,
+        _token: LS.CancellationToken,
+    ): Promise<LS.DocumentSymbol[] | undefined> => {
+        const document: LS.TextDocument | undefined = documents.get(documentSymbolParams.textDocument.uri);
+        if (document) {
+            return LanguageServices.getDocumentSymbols(document, analysisOptions);
+        }
+
+        return undefined;
     },
 );
 


### PR DESCRIPTION
This change takes advantage of the improvements in the powerquery-language-services 0.1.11 release. 

Adds support for the document Outline window
![vscode-symbols](https://user-images.githubusercontent.com/5509937/87047505-9b384e80-c1c8-11ea-9cc0-db9169dc472e.png)

Diagnostics now include errors for duplicate identifiers
![vscode-codeError](https://user-images.githubusercontent.com/5509937/87047537-a5f2e380-c1c8-11ea-9809-caa5d4688945.png)
![vscode-problems](https://user-images.githubusercontent.com/5509937/87047542-a7bca700-c1c8-11ea-9cf5-bc4b26376f83.png)

Added `"powerquery.general.locale"` configuration setting to control parser/diagnostic error message locale/culture. 
![vscode-config](https://user-images.githubusercontent.com/5509937/87047729-daff3600-c1c8-11ea-874c-e918361556ff.png)

```json
{
  "powerquery.trace.server": "verbose",
  "powerquery.general.locale": "en-US"
}
```

**Issues**
- The locale setting only takes effect on the next launch of vscode - I couldn't figure out how to pick up config changes as they happen. Requires further investigation. 
- Not all diagnostic messages are localized (needs to be resolved in powerquery-language-services)