### PR TITLE
fix syntax highlighting: time was missing from the textmate scope: st…

### DIFF
--- a/syntaxes/powerquery.tmLanguage.json
+++ b/syntaxes/powerquery.tmLanguage.json
@@ -66,7 +66,7 @@
       }
     },
     "TypeName": {
-      "match": "\\b(?:(optional|nullable)|(action|any|anynonnull|binary|date|datetime|datetimezone|duration|function|list|logical|none|null|number|record|table|text|type))\\b",
+      "match": "\\b(?:(optional|nullable)|(action|any|anynonnull|time|binary|date|datetime|datetimezone|duration|function|list|logical|none|null|number|record|table|text|type))\\b",
       "captures": {
         "1": {
           "name": "storage.modifier.powerquery"


### PR DESCRIPTION
Adds `time` to the textmate scope `storage.type.powerquery` to fix highlighting.

**Before change:** [Serialize.Type.pq](https://github.com/microsoft/DataConnectors/blob/005fd55f03789673a6aa376a00418551d4391453/samples/UnitTesting/UnitTesting.query.pq#L104)
![image](https://user-images.githubusercontent.com/3892031/91734287-644f3b00-eb70-11ea-94f9-7037f7f01792.png)

**Test Example**
```
let
    x = #time(1, 1, 1),
    TimeType = type time,
    DateType = type date,
    DateTimeType = type datetime
in
    x
```
