### PR TITLE
Declare support for untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "engines": {
         "vscode": "^1.40.0"
     },
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "categories": [
         "Programming Languages"
     ],


### PR DESCRIPTION
Resolves #80 

The extension doesn't run any external code or is otherwise side effecting. It should be safe to use in an untrusted workspace.