### PR TITLE
Fix server settings race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-powerquery",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.25",
+    "version": "0.1.26",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",


### PR DESCRIPTION
My previous change (#113) made `connection.OnInitialized` async, which introduced a possible race condition where a document operation (like get symbols) is called before `ServerSettings` the configuration has been retrieved. Fixed by adding default values. 