### PR TITLE
Code cleanup

### DIFF
--- a/server/src/errorUtils.ts
+++ b/server/src/errorUtils.ts
@@ -14,6 +14,14 @@ export interface FormatErrorMetadata {
     readonly name: string;
 }
 
+export function assertAsError<T>(value: T | Error): Error {
+    if (value instanceof Error) {
+        return value;
+    }
+
+    throw new Error(`received an error value that isn't an instanceof Error`);
+}
+
 function formatErrorMetadata(error: Error): FormatErrorMetadata {
     let maybeChild: FormatErrorMetadata | undefined;
 


### PR DESCRIPTION
- Standardizes it so any connection callback that accepts a cancellation token now does, even if ignored
- moved assertAsError into ErrorUtils
- alpha sorted helper functions in server.ts