### PR TITLE
Fix semantic tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.43",
+    "version": "0.1.44",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.43",
+            "version": "0.1.44",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.43",
+    "version": "0.1.44",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -289,10 +289,13 @@ connection.onRequest("powerquery/semanticTokens", async (params: SemanticTokenPa
     const traceManager: PQP.Trace.TraceManager = TraceManagerUtils.createTraceManager(document.uri, "semanticTokens");
     const analysis: PQLS.Analysis = createAnalysis(document, traceManager);
 
-    try {
-        return await analysis.getPartialSemanticTokens(pqpCancellationToken);
-    } catch (error) {
-        ErrorUtils.handleError(connection, error, "semanticTokens");
+    const result: PQP.Result<PQLS.PartialSemanticToken[] | undefined, PQP.CommonError.CommonError> =
+        await analysis.getPartialSemanticTokens(pqpCancellationToken);
+
+    if (PQP.ResultUtils.isOk(result)) {
+        return result.value ?? [];
+    } else {
+        ErrorUtils.handleError(connection, result.error, "semanticTokens");
 
         return [];
     }


### PR DESCRIPTION
I changed the return of a `connection.onRequest` which broke things downstream in the client when it casted it to an expected contract rather than the actual contract.