### PR TITLE
Disable debounced behavior for documentSymbols

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery-client",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-client",
-            "version": "0.0.51",
+            "version": "0.0.52",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-language-services": "0.6.5",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery-client",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "description": "VS Code part of language server",
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.49",
+    "version": "0.1.50",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.49",
+            "version": "0.1.50",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.49",
+    "version": "0.1.50",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery-scripts",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-scripts",
-            "version": "0.0.51",
+            "version": "0.0.52",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-language-services": "0.6.5",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery-scripts",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "description": "Scripts for vscode-powerquery repository",
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery-server",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-server",
-            "version": "0.0.51",
+            "version": "0.0.52",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.2",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery-server",
-    "version": "0.0.51",
+    "version": "0.0.52",
     "description": "Power Query language server implementation.",
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,15 +31,6 @@ const connection: LS.Connection = LS.createConnection(LS.ProposedFeatures.all);
 const documents: LS.TextDocuments<TextDocument> = new LS.TextDocuments(TextDocument);
 const moduleLibraries: ModuleLibraries = new ModuleLibraries();
 
-const debouncedDocumentSymbols: (
-    this: unknown,
-    params: LS.DocumentSymbolParams,
-    cancellationToken: LS.CancellationToken,
-) => Promise<LS.DocumentSymbol[] | undefined> = FuncUtils.partitionFn(
-    () => FuncUtils.debounce(documentSymbols, 250),
-    (params: LS.DocumentSymbolParams, _cancellationToken: LS.CancellationToken) => params.textDocument.uri.toString(),
-);
-
 const debouncedValidateDocument: (this: unknown, textDocument: PQLS.TextDocument) => Promise<void> =
     FuncUtils.partitionFn(
         () => FuncUtils.debounce(validateDocument, 250),
@@ -155,7 +146,7 @@ connection.onFoldingRanges(async (params: LS.FoldingRangeParams, cancellationTok
     }
 });
 
-connection.onDocumentSymbol(debouncedDocumentSymbols);
+connection.onDocumentSymbol(documentSymbols);
 
 connection.onHover(
     async (params: LS.TextDocumentPositionParams, cancellationToken: LS.CancellationToken): Promise<LS.Hover> => {


### PR DESCRIPTION
I need to investigate why adding in debounced behavior for documentSymbols caused it to no longer deliver documentSymbols.