### PR TITLE
improve handling of invariant errors

### DIFF
--- a/server/src/errorUtils.ts
+++ b/server/src/errorUtils.ts
@@ -24,13 +24,17 @@ export function handleError(
     if (PQP.CommonError.isCommonError(value) && value.innerError instanceof PQP.CommonError.CancellationError) {
         vscodeMessage = `CancellationError during ${action}.`;
         connection.console.info(vscodeMessage);
+    } else if (PQP.CommonError.isCommonError(value) && value.innerError instanceof PQP.CommonError.InvariantError) {
+        vscodeMessage = `InvariantError during ${action}.`;
+        connection.console.warn(vscodeMessage);
+        connection.console.warn(formatError(value.innerError));
     } else if (value instanceof Error) {
         const error: Error = value;
-        const userMessage: string = error.message ?? `An unknown error occured during ${action}.`;
-        connection.window.showErrorMessage(userMessage);
-
-        vscodeMessage = formatError(error);
+        // const userMessage: string = error.message ?? `An unknown error occured during ${action}.`;
+        // connection.window.showErrorMessage(userMessage);
+        vscodeMessage = `Unexpected Error during ${action}.`;
         connection.console.error(vscodeMessage);
+        connection.console.error(formatError(error));
     } else {
         vscodeMessage = `unknown error value '${value}' during ${action}.`;
         connection.console.warn(vscodeMessage);


### PR DESCRIPTION
The underlying parser or language-services layer is returning `InvariantError`s for what seems to be wrapped cancellation tokens. This results in a constant stream of error windows in VS Code. I couldn't figure out the source of the error, but it seems related to Signature Help operations and/or timeouts?

I've turned these errors into warnings at the console level, rather than error popups. 

```
[Warn  - 11:24:10 AM] InvariantError during onSignatureHelp.
[Warn  - 11:24:10 AM] {
    "topOfStack": "Error: InvariantError: Expected value to be instanceof Error - {\n    \"typeof\": \"object\",\n    \"value\": {\n        \"kind\": \"Error\",",
    "message": "InvariantError: Expected value to be instanceof Error - {\n    \"typeof\": \"object\",\n    \"value\": {\n        \"kind\": \"Error\",\n        \"error\": {\n            \"innerError\": {\n                \"cancellationToken\": {\n                    \"threshold\": 1666884242716,\n                    \"wasForceCancelled\": true\n                }\n            }\n        }\n    }\n}",
    "name": "InvariantError"
}
```
