### PR TITLE
Add Excel.CurrentWorkbook to standard-enUs library

### DIFF
--- a/server/src/library/standard/standard-enUs.json
+++ b/server/src/library/standard/standard-enUs.json
@@ -8699,6 +8699,18 @@
     "dataType": "any"
   },
   {
+    "name": "Excel.CurrentWorkbook",
+    "documentation": {
+      "description": "Returns the contents of the current Excel workbook.",
+      "longDescription": null,
+      "category": "Accessing data"
+    },
+    "functionParameters": null,
+    "completionItemType": 3,
+    "isDataSource": true,
+    "dataType": "table"
+  },
+  {
     "name": "Excel.Workbook",
     "documentation": {
       "description": "Returns the contents of the Excel workbook.",


### PR DESCRIPTION
Implements Excel.CurrentWorkbook to enUs library
https://learn.microsoft.com/en-us/powerquery-m/excel-currentworkbook

Please review `isDataSource` - I was unable to verify the correct value for this.