### PR TITLE
powerquery.extractDataflowDocument - command to extract document from dataflow.json

### DIFF
--- a/client/src/commandConstant.ts
+++ b/client/src/commandConstant.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export const enum CommandConstant {
+    ExtractDataflowDocument = "powerquery.extractDataflowDocument",
     EscapeJsonText = "powerquery.jsonEscapeText",
     EscapeMText = "powerquery.mEscapeText",
     UnescapeJsonText = "powerquery.jsonUnescapeText",

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -3,6 +3,7 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 import * as vscode from "vscode";
+import { DataflowModel } from "./dataflowModel";
 
 // https://docs.microsoft.com/en-us/powerquery-m/m-spec-lexical-structure#character-escape-sequences
 
@@ -48,9 +49,15 @@ export async function extractDataflowDocument(): Promise<void> {
     const textEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
 
     if (textEditor) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const dataflow: any = JSON.parse(textEditor.document.getText());
-        const content: string | undefined = dataflow["pbi:mashup"]?.document as string;
+        const dataflow: DataflowModel = JSON.parse(textEditor.document.getText());
+
+        if (!dataflow || !dataflow["pbi:mashup"]?.document) {
+            await vscode.window.showErrorMessage(`Unable to parse document as a dataflow.json model`);
+
+            return;
+        }
+
+        const content: string = dataflow["pbi:mashup"].document;
 
         // TODO: Can this be read from user settings/preferences?
         // The format command returns an error if we don't pass in any options.

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -53,10 +53,18 @@ export async function extractDataflowDocument(): Promise<vscode.Uri | undefined>
         return undefined;
     }
 
-    const dataflow: DataflowModel = JSON.parse(textEditor.document.getText());
+    let dataflow: DataflowModel;
+
+    try {
+        dataflow = JSON.parse(textEditor.document.getText());
+    } catch (err) {
+        await vscode.window.showErrorMessage(`Failed to parse document. Error: ${JSON.stringify(err)}`);
+
+        return undefined;
+    }
 
     if (!dataflow || !dataflow["pbi:mashup"]?.document) {
-        await vscode.window.showErrorMessage(`Unable to parse document as a dataflow.json model`);
+        await vscode.window.showErrorMessage(`Failed to parse document as a dataflow.json model`);
 
         return undefined;
     }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -46,64 +46,68 @@ export function unescapeJsonText(textEditor: vscode.TextEditor, edit: vscode.Tex
     });
 }
 
-export async function extractDataflowDocument(): Promise<void> {
+export async function extractDataflowDocument(): Promise<vscode.Uri | undefined> {
     const textEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
 
-    if (textEditor) {
-        const dataflow: DataflowModel = JSON.parse(textEditor.document.getText());
-
-        if (!dataflow || !dataflow["pbi:mashup"]?.document) {
-            await vscode.window.showErrorMessage(`Unable to parse document as a dataflow.json model`);
-
-            return;
-        }
-
-        const mashupDocument: string = dataflow["pbi:mashup"].document;
-
-        const headerComments: string[] = [
-            `// name: ${dataflow.name}`,
-            `// dataflowId: ${dataflow["ppdf:dataflowId"]}`,
-            `// modifiedTime: ${dataflow.modifiedTime}`,
-        ];
-
-        const content: string = `${headerComments.join("\r\n")}\r\n${mashupDocument}`;
-
-        const workspaceRoot: string = path.dirname(textEditor.document.fileName);
-
-        const currentEditorFileName: string = path.basename(
-            textEditor.document.fileName,
-            path.extname(textEditor.document.fileName),
-        );
-
-        const newFileUri: vscode.Uri = vscode.Uri.parse(
-            `untitled:${path.join(workspaceRoot, `${currentEditorFileName}.pq`)}`,
-        );
-
-        const document: vscode.TextDocument = await vscode.workspace.openTextDocument(newFileUri);
-        const contentEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-        contentEdit.insert(document.uri, new vscode.Position(0, 0), content);
-        await vscode.workspace.applyEdit(contentEdit);
-
-        // TODO: Can this be read from user settings/preferences?
-        // The format command returns an error if we don't pass in any options.
-        const formattingOptions: vscode.FormattingOptions = {
-            tabSize: 4,
-            insertSpaces: true,
-        };
-
-        const textEdits: vscode.TextEdit[] = await vscode.commands.executeCommand(
-            "vscode.executeFormatDocumentProvider",
-            document.uri,
-            formattingOptions,
-        );
-
-        const formatEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-        formatEdit.set(document.uri, textEdits as vscode.TextEdit[]);
-
-        await vscode.workspace.applyEdit(formatEdit);
-
-        await vscode.window.showTextDocument(document);
+    if (!textEditor) {
+        return undefined;
     }
+
+    const dataflow: DataflowModel = JSON.parse(textEditor.document.getText());
+
+    if (!dataflow || !dataflow["pbi:mashup"]?.document) {
+        await vscode.window.showErrorMessage(`Unable to parse document as a dataflow.json model`);
+
+        return undefined;
+    }
+
+    const mashupDocument: string = dataflow["pbi:mashup"].document;
+
+    const headerComments: string[] = [
+        `// name: ${dataflow.name}`,
+        `// dataflowId: ${dataflow["ppdf:dataflowId"]}`,
+        `// modifiedTime: ${dataflow.modifiedTime}`,
+    ];
+
+    const content: string = `${headerComments.join("\r\n")}\r\n${mashupDocument}`;
+
+    const workspaceRoot: string = path.dirname(textEditor.document.fileName);
+
+    const currentEditorFileName: string = path.basename(
+        textEditor.document.fileName,
+        path.extname(textEditor.document.fileName),
+    );
+
+    const newFileUri: vscode.Uri = vscode.Uri.parse(
+        `untitled:${path.join(workspaceRoot, `${currentEditorFileName}.pq`)}`,
+    );
+
+    const document: vscode.TextDocument = await vscode.workspace.openTextDocument(newFileUri);
+    const contentEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+    contentEdit.insert(document.uri, new vscode.Position(0, 0), content);
+    await vscode.workspace.applyEdit(contentEdit);
+
+    // TODO: Can this be read from user settings/preferences?
+    // The format command returns an error if we don't pass in any options.
+    const formattingOptions: vscode.FormattingOptions = {
+        tabSize: 4,
+        insertSpaces: true,
+    };
+
+    const textEdits: vscode.TextEdit[] = await vscode.commands.executeCommand(
+        "vscode.executeFormatDocumentProvider",
+        document.uri,
+        formattingOptions,
+    );
+
+    const formatEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+    formatEdit.set(document.uri, textEdits as vscode.TextEdit[]);
+
+    await vscode.workspace.applyEdit(formatEdit);
+
+    await vscode.window.showTextDocument(document);
+
+    return document.uri;
 }
 
 function removeJsonEncoding(text: string): string {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -57,7 +57,20 @@ export async function extractDataflowDocument(): Promise<void> {
             return;
         }
 
-        const content: string = dataflow["pbi:mashup"].document;
+        const mashupDocument: string = dataflow["pbi:mashup"].document;
+
+        const headerComments: string[] = [
+            `// name: ${dataflow.name}`,
+            `// dataflowId: ${dataflow["ppdf:dataflowId"]}`,
+            `// modifiedTime: ${dataflow.modifiedTime}`,
+        ];
+
+        const content: string = `${headerComments.join("\r\n")}\r\n${mashupDocument}`;
+
+        const document: vscode.TextDocument = await vscode.workspace.openTextDocument({
+            language: "powerquery",
+            content,
+        });
 
         // TODO: Can this be read from user settings/preferences?
         // The format command returns an error if we don't pass in any options.
@@ -66,21 +79,17 @@ export async function extractDataflowDocument(): Promise<void> {
             insertSpaces: true,
         };
 
-        const document: vscode.TextDocument = await vscode.workspace.openTextDocument({
-            language: "powerquery",
-            content,
-        });
-
         const textEdits: vscode.TextEdit[] = await vscode.commands.executeCommand(
             "vscode.executeFormatDocumentProvider",
             document.uri,
             formattingOptions,
         );
 
-        const edits: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-        edits.set(document.uri, textEdits as vscode.TextEdit[]);
+        const formatEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+        formatEdit.set(document.uri, textEdits as vscode.TextEdit[]);
 
-        await vscode.workspace.applyEdit(edits);
+        await vscode.workspace.applyEdit(formatEdit);
+
         await vscode.window.showTextDocument(document);
     }
 }

--- a/client/src/dataflowModel.ts
+++ b/client/src/dataflowModel.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Stripped down presentation of the dataflow.json format
+
+export interface DataflowModel {
+    name: string;
+    "ppdf:dataflowId": string;
+    culture: string;
+    modifiedTime: Date;
+    "pbi:mashup": Mashup;
+}
+
+export interface Mashup {
+    document: string;
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,6 +24,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<PowerQ
 
     commands.push(vscode.commands.registerTextEditorCommand(CommandConstant.UnescapeMText, CommandFn.unescapeMText));
 
+    commands.push(
+        vscode.commands.registerCommand(CommandConstant.ExtractDataflowDocument, CommandFn.extractDataflowDocument),
+    );
+
     // The server is implemented in node
     const serverModule: string = context.asAbsolutePath(path.join("server", "dist", "server.js"));
     // The debug options for the server

--- a/client/src/test/suite/dataflowExtractCommand.test.ts
+++ b/client/src/test/suite/dataflowExtractCommand.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { CommandConstant } from "../../commandConstant";
+import { expect } from "chai";
+
+import * as TestUtils from "./testUtils";
+
+// TODO: We could add command unit tests that use mocks to avoid UI based tests.
+suite("Dataflow Extract Command", () => {
+    suiteSetup(async () => {
+        await TestUtils.activateExtension();
+    });
+
+    test("Command is registered", async () => {
+        const commands: string[] = [CommandConstant.ExtractDataflowDocument];
+
+        const pqCommands: string[] = (await vscode.commands.getCommands(/* filterInternal */ true)).filter(
+            (cmd: string) => cmd.startsWith("powerquery."),
+        );
+
+        commands.forEach((cmd: string) => assert(pqCommands.includes(cmd), `Command not found: ${cmd}`));
+    });
+
+    test("Extract command", async () => {
+        const docUri: vscode.Uri = TestUtils.getDocUri("dataflow.json");
+        const doc: vscode.TextDocument = await vscode.workspace.openTextDocument(docUri);
+
+        await vscode.window.showTextDocument(doc);
+
+        const newDocUri: vscode.Uri | undefined = await vscode.commands.executeCommand(
+            CommandConstant.ExtractDataflowDocument,
+        );
+
+        expect(newDocUri !== undefined, "command did not return new document URI");
+    });
+});

--- a/client/src/test/testFixture/dataflow.json
+++ b/client/src/test/testFixture/dataflow.json
@@ -1,0 +1,16 @@
+{
+	"name": "MyTestDataflow",
+	"ppdf:dataflowId": "12345678-2e1a-4af9-8b92-98152e0ba2da",
+	"ppdf:owner": {},
+	"version": "1.0",
+	"culture": "en-US",
+	"modifiedTime": "2023-01-25T18:11:13.6841777+00:00",
+	"pbi:mashup": {
+		"fastCombine": false,
+		"allowNativeQueries": false,
+		"queriesMetadata": {},
+		"document": "section Section1;\r\nshared Query1 = let\r\n  Source = Table.FromRecords({[textColumn=\"123\"]}),\r\nSource2 = Table.FromRecords({[textColumn=\"123\"]}),\r\nSource3 = Table.FromRecords({[textColumn=\"123\"]}),\r\nSource4 = Table.FromRecords({[textColumn=\"123\"]})\r\nin\r\nSource;\r\n",
+		"connectionOverrides": []
+	},
+	"entities": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.50",
+    "version": "0.1.51",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.50",
+            "version": "0.1.51",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.51",
+    "version": "0.1.52",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.51",
+            "version": "0.1.52",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.51",
+    "version": "0.1.52",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "powerquery.extractDataflowDocument"
+                    "command": "powerquery.extractDataflowDocument",
+                    "when": "editorFocus"
                 },
                 {
                     "command": "powerquery.mEscapeText",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
             "commandPalette": [
                 {
                     "command": "powerquery.extractDataflowDocument",
-                    "when": "editorFocus"
+                    "when": "editorIsOpen && editorLangId == json"
                 },
                 {
                     "command": "powerquery.mEscapeText",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     ],
     "activationEvents": [
         "onLanguage:powerquery",
+        "onCommand:powerquery.extractDataflowDocument",
         "onCommand:powerquery.mEscapeText",
         "onCommand:powerquery.mUnescapeText",
         "onCommand:powerquery.jsonEscapeText",
@@ -65,6 +66,11 @@
     "publisher": "PowerQuery",
     "contributes": {
         "commands": [
+            {
+                "command": "powerquery.extractDataflowDocument",
+                "title": "Extract document from dataflow.json",
+                "category": "powerquery"
+            },
             {
                 "command": "powerquery.mEscapeText",
                 "title": "Encode selection as an M text value",
@@ -88,6 +94,9 @@
         ],
         "menus": {
             "commandPalette": [
+                {
+                    "command": "powerquery.extractDataflowDocument"
+                },
                 {
                     "command": "powerquery.mEscapeText",
                     "when": "editorHasSelection"


### PR DESCRIPTION
This change adds a helper command that extracts and formats the M document contained within the dataflow.json definition you'd get from the Power BI UX (`export .json`).

Steps:
1. Export .json for dataflow definition from Power BI
2. Save file locally
3. Open dataflow.json file in VS Code editor
4. Ctrl+Shift+P to bring up commands
5. Run `powerquery: Extract document from dataflow.json`
![image](https://user-images.githubusercontent.com/5509937/214703814-282d5392-ece4-479e-8330-3433225c79f7.png)

A new text editor should appear with the formatted M document.