### PR TITLE
Update package versions and refactor module library definition generation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "vscode-powerquery-client",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-client",
-            "version": "0.0.56",
+            "version": "0.0.57",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "0.9.2",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-language-services": "0.10.1",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageclient": "9.0.1"
             },
             "devDependencies": {
@@ -180,23 +180,23 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             },
             "engines": {
                 "node": ">=16.13.1"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             },
@@ -205,9 +205,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -6310,28 +6310,28 @@
             }
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             }
         },
         "@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "requires": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5246,20 +5246,29 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=10"
+            }
+        },
+        "node_modules/tar/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/tar/node_modules/mkdirp": {
@@ -10139,19 +10148,25 @@
             "dev": true
         },
         "tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
             "dependencies": {
+                "minipass": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+                    "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+                    "dev": true
+                },
                 "mkdirp": {
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery-client",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "description": "VS Code part of language server",
     "author": "Microsoft Corporation",
     "license": "MIT",
@@ -30,8 +30,8 @@
         "vscode": "^1.87.0"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "0.9.2",
-        "@microsoft/powerquery-parser": "0.15.5",
+        "@microsoft/powerquery-language-services": "0.10.1",
+        "@microsoft/powerquery-parser": "0.15.10",
         "vscode-languageclient": "9.0.1"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.56",
+    "version": "0.1.57",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.56",
+            "version": "0.1.57",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.56",
+    "version": "0.1.57",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.56",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "0.9.2",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-language-services": "0.10.1",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4"
             },
             "devDependencies": {
@@ -155,23 +155,23 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             },
             "engines": {
                 "node": ">=16.13.1"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             },
@@ -180,9 +180,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -2262,28 +2262,28 @@
             }
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             }
         },
         "@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "requires": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -30,8 +30,8 @@
         "node": ">=16.13.2"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "0.9.2",
-        "@microsoft/powerquery-parser": "0.15.5",
+        "@microsoft/powerquery-language-services": "0.10.1",
+        "@microsoft/powerquery-parser": "0.15.10",
         "vscode-languageserver-textdocument": "1.0.4"
     },
     "devDependencies": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "vscode-powerquery-server",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-server",
-            "version": "0.0.56",
+            "version": "0.0.57",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-language-services": "0.9.2",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-language-services": "0.10.1",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver": "9.0.1",
                 "vscode-languageserver-textdocument": "1.0.11",
                 "vscode-languageserver-types": "3.17.5"
@@ -215,23 +215,23 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             },
             "engines": {
                 "node": ">=16.13.1"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             },
@@ -250,9 +250,9 @@
             "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"
@@ -3540,20 +3540,20 @@
             }
         },
         "@microsoft/powerquery-formatter": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.11.tgz",
-            "integrity": "sha512-NEJnBlzTgnQM/xfb0RaeAG6DRxVtMclnodWLVYfgFOzMVU5dzrkwLizmCkthEXBPmo4SmO4tYQYwCRqqqy1eCw==",
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.14.tgz",
+            "integrity": "sha512-XUe1W7Yd7gsnNEJVIWaqFaX3I/Sxdx3UHfVD4+ndQG75P2/2eF1b9B6kQxlRbr2QMNXoXqhC7lpeY7OA8PNavw==",
             "requires": {
-                "@microsoft/powerquery-parser": "0.15.5"
+                "@microsoft/powerquery-parser": "0.15.10"
             }
         },
         "@microsoft/powerquery-language-services": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.9.2.tgz",
-            "integrity": "sha512-YMfI9EBVrBGfis+WcOEykeLRa7L4CYehgBkct6ZcS6bcwNHfCNaAK2wrP7BtxGiroAGo9BIEbuq88bIjSgniWg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.10.1.tgz",
+            "integrity": "sha512-/pzGcIR2A3sipxoHiug6HnHCtuCTt/hFbbWA/JPsGMD84e/ZV3yCVMLlp6wXiupPOrT7oR9bjXtQWHMOnm+urA==",
             "requires": {
-                "@microsoft/powerquery-formatter": "0.3.11",
-                "@microsoft/powerquery-parser": "0.15.5",
+                "@microsoft/powerquery-formatter": "0.3.14",
+                "@microsoft/powerquery-parser": "0.15.10",
                 "vscode-languageserver-textdocument": "1.0.4",
                 "vscode-languageserver-types": "3.17.1"
             },
@@ -3571,9 +3571,9 @@
             }
         },
         "@microsoft/powerquery-parser": {
-            "version": "0.15.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.5.tgz",
-            "integrity": "sha512-wk+tcBWuarVfZ/NAtjGuTQ24oVkCvwnfSQQyf6l/iHqCezCUmyXN4HCDmbDMMGXVCxofDI9szbLJjxekN10rcg==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.15.10.tgz",
+            "integrity": "sha512-WdRBo//uDBW+oy9a9IZ7+R3KuLphp4RWlFglzjtQMzJSW7Uve8J8o29UlF9AjplV1cmsQ3vkrbOhxTB7LEya/Q==",
             "requires": {
                 "grapheme-splitter": "^1.0.4",
                 "performance-now": "^2.1.0"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery-server",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "description": "Power Query language server implementation.",
     "author": "Microsoft Corporation",
     "license": "MIT",
@@ -30,9 +30,9 @@
         "node": ">=18.17.0"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "0.3.11",
-        "@microsoft/powerquery-language-services": "0.9.2",
-        "@microsoft/powerquery-parser": "0.15.5",
+        "@microsoft/powerquery-formatter": "0.3.14",
+        "@microsoft/powerquery-language-services": "0.10.1",
+        "@microsoft/powerquery-parser": "0.15.10",
         "vscode-languageserver": "9.0.1",
         "vscode-languageserver-textdocument": "1.0.11",
         "vscode-languageserver-types": "3.17.5"

--- a/server/src/library/libraryUtils.ts
+++ b/server/src/library/libraryUtils.ts
@@ -12,7 +12,7 @@ import { PartialResult, PartialResultUtils } from "@microsoft/powerquery-parser"
 
 import * as SdkLibrarySymbolsEnUs from "./sdk/sdk-enUs.json";
 import * as StandardLibrarySymbolsEnUs from "./standard/standard-enUs.json";
-import { createExternalTypeResolver } from "./libraryTypeResolver";
+import { createExternalTypeResolver, wrapSmartTypeResolver } from "./libraryTypeResolver";
 
 export function getOrCreateStandardLibrary(locale?: string): Library.ILibrary {
     return getOrCreateLibrary(
@@ -57,13 +57,15 @@ function getOrCreateLibrary(
             );
 
         const staticLibrary: Library.ILibrary = {
-            externalTypeResolver: LibraryDefinitionUtils.externalTypeResolver({
-                staticLibraryDefinitions,
-                dynamicLibraryDefinitions: () => new Map(),
-            }),
+            externalTypeResolver: wrapSmartTypeResolver(
+                LibraryDefinitionUtils.externalTypeResolver({
+                    staticLibraryDefinitions,
+                    dynamicLibraryDefinitions: () => emptyReadonlyMap,
+                }),
+            ),
             libraryDefinitions: {
                 staticLibraryDefinitions,
-                dynamicLibraryDefinitions: () => new Map(),
+                dynamicLibraryDefinitions: () => emptyReadonlyMap,
             },
         };
 
@@ -131,7 +133,7 @@ function getOrCreateStaticLibraryDefinitions(
                 .join(", ");
 
             console.warn(
-                `$libraryJson.setter failed to create library definitions for the following symbolNames: ${csvSymbolNames}`,
+                `$libraryJson.setter failed to create library definitions for the following symbolNames: [${csvSymbolNames}]`,
             );
         }
 
@@ -140,6 +142,8 @@ function getOrCreateStaticLibraryDefinitions(
 
     return PQP.MapUtils.assertGet(staticLibraryDefinitionsByLocale, locale);
 }
+
+const emptyReadonlyMap: ReadonlyMap<string, Library.TLibraryDefinition> = new Map();
 
 const sdkLibraryByLocale: Map<string, Library.ILibrary> = new Map();
 const sdkStaticLibraryDefinitionsByLocale: Map<string, ReadonlyMap<string, Library.TLibraryDefinition>> = new Map();

--- a/server/src/library/moduleLibraries.ts
+++ b/server/src/library/moduleLibraries.ts
@@ -6,8 +6,6 @@ import { Library, LibrarySymbol, LibrarySymbolUtils } from "@microsoft/powerquer
 import { PartialResult, PartialResultUtils } from "@microsoft/powerquery-parser";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-import { LibraryDefinitionsGetter } from "./libraryTypeResolver";
-
 export interface ModuleLibraryTrieNodeCache {
     localizedLibrary?: PQLS.Library.ILibrary;
 }
@@ -15,8 +13,8 @@ export interface ModuleLibraryTrieNodeCache {
 export class ModuleLibraryTreeNode {
     static defaultRoot: ModuleLibraryTreeNode = new ModuleLibraryTreeNode();
 
-    private _librarySymbols?: ReadonlyArray<LibrarySymbol.LibrarySymbol>;
-    private _libraryDefinitions: ReadonlyMap<string, PQLS.Library.TLibraryDefinition> = new Map();
+    private _librarySymbols: ReadonlyArray<LibrarySymbol.LibrarySymbol> | undefined;
+    private _staticLibraryDefinitions: ReadonlyMap<string, PQLS.Library.TLibraryDefinition> = new Map();
     public textDocument?: TextDocument;
     public readonly cache: ModuleLibraryTrieNodeCache = {};
 
@@ -28,32 +26,32 @@ export class ModuleLibraryTreeNode {
         return this._librarySymbols;
     }
 
-    set libraryJson(val: ReadonlyArray<LibrarySymbol.LibrarySymbol> | undefined) {
-        this._librarySymbols = val;
-        this._libraryDefinitions = new Map();
+    set libraryJson(librarySymbols: ReadonlyArray<LibrarySymbol.LibrarySymbol> | undefined) {
+        this._librarySymbols = librarySymbols;
+        this._staticLibraryDefinitions = new Map();
 
-        if (val && Array.isArray(val)) {
+        if (librarySymbols) {
             const libraryDefinitionsResult: PartialResult<
-                Library.LibraryDefinitions,
+                ReadonlyMap<string, Library.TLibraryDefinition>,
                 LibrarySymbolUtils.IncompleteLibraryDefinitions,
                 ReadonlyArray<LibrarySymbol.LibrarySymbol>
-            > = LibrarySymbolUtils.createLibraryDefinitions(val);
+            > = LibrarySymbolUtils.createLibraryDefinitions(librarySymbols);
 
-            let libraryDefinitions: Library.LibraryDefinitions;
+            let staticLibraryDefinitions: ReadonlyMap<string, Library.TLibraryDefinition>;
             let failedSymbols: ReadonlyArray<LibrarySymbol.LibrarySymbol>;
 
             if (PartialResultUtils.isOk(libraryDefinitionsResult)) {
-                libraryDefinitions = libraryDefinitionsResult.value;
+                staticLibraryDefinitions = libraryDefinitionsResult.value;
                 failedSymbols = [];
             } else if (PartialResultUtils.isIncomplete(libraryDefinitionsResult)) {
-                libraryDefinitions = libraryDefinitionsResult.partial.libraryDefinitions;
+                staticLibraryDefinitions = libraryDefinitionsResult.partial.libraryDefinitions;
                 failedSymbols = libraryDefinitionsResult.partial.invalidSymbols;
             } else {
-                libraryDefinitions = new Map();
+                staticLibraryDefinitions = new Map();
                 failedSymbols = libraryDefinitionsResult.error;
             }
 
-            this._libraryDefinitions = libraryDefinitions;
+            this._staticLibraryDefinitions = staticLibraryDefinitions;
 
             if (failedSymbols.length) {
                 const csvSymbolNames: string = failedSymbols
@@ -67,18 +65,16 @@ export class ModuleLibraryTreeNode {
         }
     }
 
-    get libraryDefinitions(): PQLS.Library.LibraryDefinitions {
-        return this._libraryDefinitions;
+    get libraryDefinitions(): () => ReadonlyMap<string, Library.TLibraryDefinition> {
+        return () => this._staticLibraryDefinitions;
     }
-
-    public libraryDefinitionsGetter: LibraryDefinitionsGetter = () => this.libraryDefinitions;
 
     public readonly children: Map<string, ModuleLibraryTreeNode> = new Map();
 
     constructor(private readonly parent?: ModuleLibraryTreeNode, private readonly currentPath: string = "") {}
 
     insert(
-        paths: string[],
+        paths: ReadonlyArray<string>,
         visitorContext?: { closestModuleLibraryTreeNodeOfDefinitions: ModuleLibraryTreeNode },
     ): ModuleLibraryTreeNode {
         if (paths.length === 0) {
@@ -90,10 +86,10 @@ export class ModuleLibraryTreeNode {
 
         let child: ModuleLibraryTreeNode;
 
-        const maybeOneChild: ModuleLibraryTreeNode | undefined = this.children.get(currentPath);
+        const maybeChild: ModuleLibraryTreeNode | undefined = this.children.get(currentPath);
 
-        if (maybeOneChild) {
-            child = maybeOneChild;
+        if (maybeChild) {
+            child = maybeChild;
 
             if (visitorContext && child.libraryJson) {
                 visitorContext.closestModuleLibraryTreeNodeOfDefinitions = child;
@@ -111,16 +107,16 @@ export class ModuleLibraryTreeNode {
             this.parent.children.delete(this.currentPath);
         }
 
-        this._libraryDefinitions = new Map();
+        this._staticLibraryDefinitions = new Map();
         this._librarySymbols = [];
     }
 
     collectTextDocumentBeneath(visitorContext: { textDocuments: TextDocument[] }): void {
-        for (const theNode of this.children.values()) {
-            if (theNode.textDocument) {
-                visitorContext.textDocuments.push(theNode.textDocument);
+        for (const node of this.children.values()) {
+            if (node.textDocument) {
+                visitorContext.textDocuments.push(node.textDocument);
             } else {
-                theNode.collectTextDocumentBeneath(visitorContext);
+                node.collectTextDocumentBeneath(visitorContext);
             }
         }
     }
@@ -130,46 +126,46 @@ export class ModuleLibraryTreeNode {
  * A mutable container of module libraries by uri path
  */
 export class ModuleLibraries {
-    private readonly triedRoot: ModuleLibraryTreeNode = ModuleLibraryTreeNode.defaultRoot;
-    private readonly openedTextDocumentTreeNodeMap: Map<string, ModuleLibraryTreeNode> = new Map();
+    private readonly root: ModuleLibraryTreeNode = ModuleLibraryTreeNode.defaultRoot;
+    private readonly moduleLibraryTreeNodeByTextDocumentUri: Map<string, ModuleLibraryTreeNode> = new Map();
 
-    static splitPath(uriPath: string): string[] {
+    static splitPath(uriPath: string): ReadonlyArray<string> {
         return uriPath.split("/").filter(Boolean);
     }
 
-    addOneModuleLibrary(uriPath: string, libraryJson: ReadonlyArray<LibrarySymbol.LibrarySymbol>): TextDocument[] {
-        const spitedPath: string[] = ModuleLibraries.splitPath(uriPath);
+    addModuleLibrary(uriPath: string, libraryJson: ReadonlyArray<LibrarySymbol.LibrarySymbol>): TextDocument[] {
+        const splittedPath: ReadonlyArray<string> = ModuleLibraries.splitPath(uriPath);
         const visitorContext: { textDocuments: [] } = { textDocuments: [] };
-        const theNode: ModuleLibraryTreeNode = this.triedRoot.insert(spitedPath);
-        theNode.libraryJson = libraryJson;
-        theNode.collectTextDocumentBeneath(visitorContext);
+        const node: ModuleLibraryTreeNode = this.root.insert(splittedPath);
+        node.libraryJson = libraryJson;
+        node.collectTextDocumentBeneath(visitorContext);
 
         return visitorContext.textDocuments;
     }
 
-    addOneTextDocument(textDocument: TextDocument): ModuleLibraryTreeNode {
-        const spitedPath: string[] = ModuleLibraries.splitPath(textDocument.uri);
+    addTextDocument(textDocument: TextDocument): ModuleLibraryTreeNode {
+        const splittedPath: ReadonlyArray<string> = ModuleLibraries.splitPath(textDocument.uri);
 
         const visitorContext: { closestModuleLibraryTreeNodeOfDefinitions: ModuleLibraryTreeNode } = {
-            closestModuleLibraryTreeNodeOfDefinitions: this.triedRoot,
+            closestModuleLibraryTreeNodeOfDefinitions: this.root,
         };
 
-        const theNode: ModuleLibraryTreeNode = this.triedRoot.insert(spitedPath, visitorContext);
+        const theNode: ModuleLibraryTreeNode = this.root.insert(splittedPath, visitorContext);
         theNode.textDocument = textDocument;
-        this.openedTextDocumentTreeNodeMap.set(textDocument.uri, theNode);
+        this.moduleLibraryTreeNodeByTextDocumentUri.set(textDocument.uri, theNode);
 
         return visitorContext.closestModuleLibraryTreeNodeOfDefinitions;
     }
 
-    removeOneTextDocument(textDocument: TextDocument): void {
-        const theDocUri: string = textDocument.uri;
+    removeTextDocument(textDocument: TextDocument): void {
+        const uri: string = textDocument.uri;
 
-        const maybeModuleLibraryTreeNode: ModuleLibraryTreeNode | undefined =
-            this.openedTextDocumentTreeNodeMap.get(theDocUri);
+        const moduleLibraryTreeNode: ModuleLibraryTreeNode | undefined =
+            this.moduleLibraryTreeNodeByTextDocumentUri.get(uri);
 
-        if (maybeModuleLibraryTreeNode) {
-            this.openedTextDocumentTreeNodeMap.delete(theDocUri);
-            maybeModuleLibraryTreeNode.remove();
+        if (moduleLibraryTreeNode) {
+            this.moduleLibraryTreeNodeByTextDocumentUri.delete(uri);
+            moduleLibraryTreeNode.remove();
         }
     }
 
@@ -177,7 +173,7 @@ export class ModuleLibraries {
     getLibraryCount(): number {
         let count: number = 0;
 
-        this.triedRoot.children.forEach((node: ModuleLibraryTreeNode) => {
+        this.root.children.forEach((node: ModuleLibraryTreeNode) => {
             count += node.libraryJson?.length ?? 0;
         });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -113,7 +113,7 @@ documents.onDidChangeContent(
 
 documents.onDidClose(async (event: LS.TextDocumentChangeEvent<TextDocument>) => {
     // remove the document from module library container and we no longer need to trace it
-    moduleLibraries.removeOneTextDocument(event.document);
+    moduleLibraries.removeTextDocument(event.document);
 
     // Clear any errors associated with this file
     await connection.sendDiagnostics({
@@ -272,10 +272,7 @@ connection.onRequest("powerquery/semanticTokens", async (params: SemanticTokenPa
 
 // TODO: make async
 connection.onRequest("powerquery/moduleLibraryUpdated", (params: ModuleLibraryUpdatedParams): void => {
-    const allTextDocuments: TextDocument[] = moduleLibraries.addOneModuleLibrary(
-        params.workspaceUriPath,
-        params.library,
-    );
+    const allTextDocuments: TextDocument[] = moduleLibraries.addModuleLibrary(params.workspaceUriPath, params.library);
 
     // need to validate those currently opened documents
     void Promise.all(allTextDocuments.map(debouncedValidateDocument));

--- a/server/src/test/standardLibrary.ts
+++ b/server/src/test/standardLibrary.ts
@@ -68,7 +68,7 @@ async function assertHoverContentEquals(text: string, expected: string): Promise
 
 const assertIsFunction: (
     definition: PQLS.Library.TLibraryDefinition,
-) => asserts definition is PQLS.Library.LibraryFunction = PQLS.LibraryUtils.assertIsFunction;
+) => asserts definition is PQLS.Library.LibraryFunction = PQLS.LibraryDefinitionUtils.assertIsFunction;
 
 function assertAsMarkupContent(value: Hover["contents"]): MarkupContent {
     assertIsMarkupContent(value);
@@ -108,7 +108,7 @@ describe(`StandardLibrary`, () => {
             const definitionKey: string = "BinaryOccurrence.Required";
 
             const libraryDefinition: PQLS.Library.TLibraryDefinition | undefined =
-                library.libraryDefinitions.get(definitionKey);
+                library.libraryDefinitions.staticLibraryDefinitions.get(definitionKey);
 
             if (libraryDefinition === undefined) {
                 throw new Error(`expected constant '${definitionKey}' was not found`);
@@ -124,7 +124,7 @@ describe(`StandardLibrary`, () => {
             const exportKey: string = "List.Distinct";
 
             const libraryDefinition: PQLS.Library.TLibraryDefinition | undefined =
-                library.libraryDefinitions.get(exportKey);
+                library.libraryDefinitions.staticLibraryDefinitions.get(exportKey);
 
             if (libraryDefinition === undefined) {
                 throw new Error(`expected constant '${exportKey}' was not found`);
@@ -141,7 +141,7 @@ describe(`StandardLibrary`, () => {
             const exportKey: string = "#date";
 
             const libraryDefinition: PQLS.Library.TLibraryDefinition | undefined =
-                library.libraryDefinitions.get(exportKey);
+                library.libraryDefinitions.staticLibraryDefinitions.get(exportKey);
 
             if (libraryDefinition === undefined) {
                 throw new Error(`expected constant '${exportKey}' was not found`);
@@ -213,7 +213,7 @@ describe(`moduleLibraryUpdated`, () => {
         it("ModuleLibraries", () => {
             const libraryJson: PQLS.LibrarySymbol.LibrarySymbol[] = JSON.parse(sdkJsonStr);
             const moduleLibraries: ModuleLibraries = new ModuleLibraries();
-            moduleLibraries.addOneModuleLibrary("sdk", libraryJson);
+            moduleLibraries.addModuleLibrary("sdk", libraryJson);
             expect(moduleLibraries.getLibraryCount()).to.equal(1, "expected 1 export");
         });
     });

--- a/server/src/test/standardLibrary.ts
+++ b/server/src/test/standardLibrary.ts
@@ -157,7 +157,7 @@ describe(`StandardLibrary`, () => {
         });
     });
 
-    describe(`StandardLibrary `, () => {
+    describe(`StandardLibrary`, () => {
         describe(`Table.AddColumn`, () => {
             it(`getHover`, async () => {
                 const expression: string = `let foo = Table.AddColumn(1 as table, "bar", each 1) in fo|o`;


### PR DESCRIPTION
One of the biggest changes in upgrading PQLS is that the LibraryDefinitions type has been changed. It now has a new parameter, dynamicLibraryDefinitions, which is a lazily evaluated lambda which returns library definitions. This is where the module definitions (definitions that work across files) are generated/stored.

Additionally, I updated the codebase's style to better match the rest of it.