### PR TITLE
﻿Add LSP semantic token support for Power Query

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,8 +7,8 @@
             "name": "vscode-powerquery-client",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "^0.14.1",
-                "@microsoft/powerquery-parser": "^0.18.5",
+                "@microsoft/powerquery-language-services": "^1.0.0",
+                "@microsoft/powerquery-parser": "^0.19.0",
                 "vscode-languageclient": "^9.0.1"
             },
             "devDependencies": {
@@ -413,25 +413,25 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.20.tgz",
-            "integrity": "sha512-8EA+1GAO1qaQqxy8iGm6n7gp3ac2FCboJ9A0gbusdqhOpbs3RAjInna6chk8mT0vixusShL57VWPEdXG4LxHxQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-1.0.0.tgz",
+            "integrity": "sha512-Yyo9/stkwd8GbdThOnHDHdJTkl0VIux6W6pj7Tm/LYBt+wTGVDHfZsncriTzWI4lQ5ybRj0mwLPwvZkafWxmNA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.18.5"
+                "@microsoft/powerquery-parser": "0.19.0"
             },
             "engines": {
                 "node": ">=22"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
-            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-1.0.0.tgz",
+            "integrity": "sha512-Tweh19kBdZ0AlwHOJNQ+RT5h6AwLqNZZzuUNhlIN7mr2HR+EnCFG9YwXqThI6oZXWETdFbVZOqZBEoCmX5Y/RA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.20",
-                "@microsoft/powerquery-parser": "0.18.5",
+                "@microsoft/powerquery-formatter": "1.0.0",
+                "@microsoft/powerquery-parser": "0.19.0",
                 "vscode-languageserver-textdocument": "1.0.12",
                 "vscode-languageserver-types": "3.17.5"
             },
@@ -440,9 +440,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.18.5.tgz",
-            "integrity": "sha512-9h7gp3fJ7p2Nb+2hE/xeMMw3wGVs1sJ65JTKxXu7YHISLhHuaA68u1FEgzhWt9qu3M0iOXcSZDV26WMa0lteng==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.19.0.tgz",
+            "integrity": "sha512-/ZsfsejTGyyH20g502GiJ7q6E2JgyXmJKFgpFON7YErs3l+iyg62SJFp6EhB3Xz06bDbQiSkn3oDFHC9C5WtTg==",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,7 +7,7 @@
             "name": "vscode-powerquery-client",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "^0.11.9",
+                "@microsoft/powerquery-language-services": "^0.14.1",
                 "@microsoft/powerquery-parser": "^0.18.5",
                 "vscode-languageclient": "^9.0.1"
             },
@@ -425,9 +425,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.11.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.11.9.tgz",
-            "integrity": "sha512-V7HTmJqoQwUPLOmB5AH30K2ZwG5SKqNXnRGgINGtY8zRglunB3TKS7yjmtLNCY9yNwlhDFNtkmZPrQ//uZL+fA==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
+            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.20",

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
         "vscode": "^1.100.0"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "^0.11.9",
+        "@microsoft/powerquery-language-services": "^0.14.1",
         "@microsoft/powerquery-parser": "^0.18.5",
         "vscode-languageclient": "^9.0.1"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -29,8 +29,8 @@
         "vscode": "^1.100.0"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "^0.14.1",
-        "@microsoft/powerquery-parser": "^0.18.5",
+        "@microsoft/powerquery-language-services": "^1.0.0",
+        "@microsoft/powerquery-parser": "^0.19.0",
         "vscode-languageclient": "^9.0.1"
     },
     "devDependencies": {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -60,15 +60,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<PowerQ
     // Start the client. This will also launch the server.
     await client.start();
 
-    // TODO: Move this to the LSP based API.
-    // context.subscriptions.push(
-    //     vscode.languages.registerDocumentSemanticTokensProvider(
-    //         { language: "powerquery" },
-    //         Subscriptions.createDocumentSemanticTokensProvider(client),
-    //         Subscriptions.SemanticTokensLegend,
-    //     ),
-    // );
-
     librarySymbolClient = new LibrarySymbolClient(client);
     librarySymbolManager = new LibrarySymbolManager(librarySymbolClient, client);
 

--- a/client/src/test/suite/diagnostics.test.ts
+++ b/client/src/test/suite/diagnostics.test.ts
@@ -17,8 +17,7 @@ suite("Diagnostics: Simple", () => {
     test("Simple diagnostics test", async () =>
         await testDiagnostics(docUri, [
             {
-                message:
-                    "Expected to find a equal operator <'='>, but a keyword <'not'> was found instead",
+                message: "Expected to find a equal operator <'='>, but a keyword <'not'> was found instead",
                 range: new vscode.Range(0, 9, 0, 12),
                 severity: vscode.DiagnosticSeverity.Error,
             },

--- a/client/src/test/suite/diagnostics.test.ts
+++ b/client/src/test/suite/diagnostics.test.ts
@@ -18,7 +18,7 @@ suite("Diagnostics: Simple", () => {
         await testDiagnostics(docUri, [
             {
                 message:
-                    "Expected to find a equal operator <'='>, but a not equal to operator ('<>') was found instead",
+                    "Expected to find a equal operator <'='>, but a keyword <'not'> was found instead",
                 range: new vscode.Range(0, 9, 0, 12),
                 severity: vscode.DiagnosticSeverity.Error,
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.66",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "0.1.66",
+            "version": "1.0.0",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "hasInstallScript": true,
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -282,6 +282,27 @@
                 "scopeName": "source.powerquery",
                 "path": "./syntaxes/powerquery.tmLanguage.json"
             }
+        ],
+        "semanticTokenScopes": [
+            {
+                "language": "powerquery",
+                "scopes": {
+                    "variable": ["variable.other.readwrite.powerquery"],
+                    "function": ["entity.name.function.powerquery"],
+                    "function.defaultLibrary": ["support.function.powerquery"],
+                    "parameter": ["variable.parameter.powerquery"],
+                    "property": ["variable.other.property.powerquery"],
+                    "keyword": ["keyword.control.powerquery"],
+                    "number": ["constant.numeric.powerquery"],
+                    "string": ["string.quoted.powerquery"],
+                    "comment": ["comment.powerquery"],
+                    "type": ["entity.name.type.powerquery"],
+                    "namespace": ["entity.name.namespace.powerquery"],
+                    "operator": ["keyword.operator.powerquery"],
+                    "typeParameter": ["entity.name.type.parameter.powerquery"],
+                    "modifier": ["keyword.modifier.powerquery"]
+                }
+            }
         ]
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-powerquery",
-    "version": "0.1.66",
+    "version": "1.0.0",
     "displayName": "Power Query / M Language",
     "description": "Language service for the Power Query / M formula language",
     "author": "Microsoft Corporation",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,8 +7,8 @@
             "name": "vscode-powerquery-scripts",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "^0.14.1",
-                "@microsoft/powerquery-parser": "^0.18.5",
+                "@microsoft/powerquery-language-services": "^1.0.0",
+                "@microsoft/powerquery-parser": "^0.19.0",
                 "vscode-languageserver-textdocument": "^1.0.4"
             },
             "devDependencies": {
@@ -380,25 +380,25 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.20.tgz",
-            "integrity": "sha512-8EA+1GAO1qaQqxy8iGm6n7gp3ac2FCboJ9A0gbusdqhOpbs3RAjInna6chk8mT0vixusShL57VWPEdXG4LxHxQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-1.0.0.tgz",
+            "integrity": "sha512-Yyo9/stkwd8GbdThOnHDHdJTkl0VIux6W6pj7Tm/LYBt+wTGVDHfZsncriTzWI4lQ5ybRj0mwLPwvZkafWxmNA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.18.5"
+                "@microsoft/powerquery-parser": "0.19.0"
             },
             "engines": {
                 "node": ">=22"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
-            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-1.0.0.tgz",
+            "integrity": "sha512-Tweh19kBdZ0AlwHOJNQ+RT5h6AwLqNZZzuUNhlIN7mr2HR+EnCFG9YwXqThI6oZXWETdFbVZOqZBEoCmX5Y/RA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.20",
-                "@microsoft/powerquery-parser": "0.18.5",
+                "@microsoft/powerquery-formatter": "1.0.0",
+                "@microsoft/powerquery-parser": "0.19.0",
                 "vscode-languageserver-textdocument": "1.0.12",
                 "vscode-languageserver-types": "3.17.5"
             },
@@ -407,9 +407,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.18.5.tgz",
-            "integrity": "sha512-9h7gp3fJ7p2Nb+2hE/xeMMw3wGVs1sJ65JTKxXu7YHISLhHuaA68u1FEgzhWt9qu3M0iOXcSZDV26WMa0lteng==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.19.0.tgz",
+            "integrity": "sha512-/ZsfsejTGyyH20g502GiJ7q6E2JgyXmJKFgpFON7YErs3l+iyg62SJFp6EhB3Xz06bDbQiSkn3oDFHC9C5WtTg==",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,7 +7,7 @@
             "name": "vscode-powerquery-scripts",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-language-services": "^0.11.9",
+                "@microsoft/powerquery-language-services": "^0.14.1",
                 "@microsoft/powerquery-parser": "^0.18.5",
                 "vscode-languageserver-textdocument": "^1.0.4"
             },
@@ -392,9 +392,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.11.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.11.9.tgz",
-            "integrity": "sha512-V7HTmJqoQwUPLOmB5AH30K2ZwG5SKqNXnRGgINGtY8zRglunB3TKS7yjmtLNCY9yNwlhDFNtkmZPrQ//uZL+fA==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
+            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.20",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,8 +27,8 @@
         "node": ">= 22"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "^0.14.1",
-        "@microsoft/powerquery-parser": "^0.18.5",
+        "@microsoft/powerquery-language-services": "^1.0.0",
+        "@microsoft/powerquery-parser": "^0.19.0",
         "vscode-languageserver-textdocument": "^1.0.4"
     },
     "devDependencies": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,7 +27,7 @@
         "node": ">= 22"
     },
     "dependencies": {
-        "@microsoft/powerquery-language-services": "^0.11.9",
+        "@microsoft/powerquery-language-services": "^0.14.1",
         "@microsoft/powerquery-parser": "^0.18.5",
         "vscode-languageserver-textdocument": "^1.0.4"
     },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "^0.3.17",
-                "@microsoft/powerquery-language-services": "^0.11.9",
+                "@microsoft/powerquery-language-services": "^0.14.1",
                 "@microsoft/powerquery-parser": "^0.18.5",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.11",
@@ -415,9 +415,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.11.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.11.9.tgz",
-            "integrity": "sha512-V7HTmJqoQwUPLOmB5AH30K2ZwG5SKqNXnRGgINGtY8zRglunB3TKS7yjmtLNCY9yNwlhDFNtkmZPrQ//uZL+fA==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
+            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-formatter": "0.3.20",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,9 +7,9 @@
             "name": "vscode-powerquery-server",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "^0.3.17",
-                "@microsoft/powerquery-language-services": "^0.14.1",
-                "@microsoft/powerquery-parser": "^0.18.5",
+                "@microsoft/powerquery-formatter": "^1.0.0",
+                "@microsoft/powerquery-language-services": "^1.0.0",
+                "@microsoft/powerquery-parser": "^0.19.0",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-languageserver-types": "^3.17.5"
@@ -403,25 +403,25 @@
             }
         },
         "node_modules/@microsoft/powerquery-formatter": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-0.3.20.tgz",
-            "integrity": "sha512-8EA+1GAO1qaQqxy8iGm6n7gp3ac2FCboJ9A0gbusdqhOpbs3RAjInna6chk8mT0vixusShL57VWPEdXG4LxHxQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-formatter/-/powerquery-formatter-1.0.0.tgz",
+            "integrity": "sha512-Yyo9/stkwd8GbdThOnHDHdJTkl0VIux6W6pj7Tm/LYBt+wTGVDHfZsncriTzWI4lQ5ybRj0mwLPwvZkafWxmNA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-parser": "0.18.5"
+                "@microsoft/powerquery-parser": "0.19.0"
             },
             "engines": {
                 "node": ">=22"
             }
         },
         "node_modules/@microsoft/powerquery-language-services": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-0.14.1.tgz",
-            "integrity": "sha512-7os9xyNEqZO1tg1VxQbOG9lCpOifYPZHR3dHx05/2teEykDCc4AZoCXrZ+COl3lQCySlzloAzF2+TAgZ2mXNWw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-language-services/-/powerquery-language-services-1.0.0.tgz",
+            "integrity": "sha512-Tweh19kBdZ0AlwHOJNQ+RT5h6AwLqNZZzuUNhlIN7mr2HR+EnCFG9YwXqThI6oZXWETdFbVZOqZBEoCmX5Y/RA==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/powerquery-formatter": "0.3.20",
-                "@microsoft/powerquery-parser": "0.18.5",
+                "@microsoft/powerquery-formatter": "1.0.0",
+                "@microsoft/powerquery-parser": "0.19.0",
                 "vscode-languageserver-textdocument": "1.0.12",
                 "vscode-languageserver-types": "3.17.5"
             },
@@ -430,9 +430,9 @@
             }
         },
         "node_modules/@microsoft/powerquery-parser": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.18.5.tgz",
-            "integrity": "sha512-9h7gp3fJ7p2Nb+2hE/xeMMw3wGVs1sJ65JTKxXu7YHISLhHuaA68u1FEgzhWt9qu3M0iOXcSZDV26WMa0lteng==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.19.0.tgz",
+            "integrity": "sha512-/ZsfsejTGyyH20g502GiJ7q6E2JgyXmJKFgpFON7YErs3l+iyg62SJFp6EhB3Xz06bDbQiSkn3oDFHC9C5WtTg==",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@microsoft/powerquery-formatter": "^0.3.17",
-        "@microsoft/powerquery-language-services": "^0.11.9",
+        "@microsoft/powerquery-language-services": "^0.14.1",
         "@microsoft/powerquery-parser": "^0.18.5",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",

--- a/server/package.json
+++ b/server/package.json
@@ -29,9 +29,9 @@
         "node": ">= 22"
     },
     "dependencies": {
-        "@microsoft/powerquery-formatter": "^0.3.17",
-        "@microsoft/powerquery-language-services": "^0.14.1",
-        "@microsoft/powerquery-parser": "^0.18.5",
+        "@microsoft/powerquery-formatter": "^1.0.0",
+        "@microsoft/powerquery-language-services": "^1.0.0",
+        "@microsoft/powerquery-parser": "^0.19.0",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-languageserver-types": "^3.17.5"

--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import type * as LS from "vscode-languageserver/node";
+import * as PQLS from "@microsoft/powerquery-language-services";
+
+const semanticTokenTypesLegend: ReadonlyArray<string> = [
+    "variable",
+    "function",
+    "parameter",
+    "property",
+    "keyword",
+    "number",
+    "string",
+    "comment",
+    "type",
+    "namespace",
+    "operator",
+    "typeParameter",
+    "modifier",
+];
+
+const semanticTokenModifiersLegend: ReadonlyArray<string> = [
+    "declaration",
+    "definition",
+    "readonly",
+    "defaultLibrary",
+    "deprecated",
+];
+
+export const semanticTokensLegend: LS.SemanticTokensLegend = {
+    tokenTypes: semanticTokenTypesLegend as string[],
+    tokenModifiers: semanticTokenModifiersLegend as string[],
+};
+
+export function encodeSemanticTokens(tokens: ReadonlyArray<PQLS.PartialSemanticToken>): number[] {
+    const sorted: ReadonlyArray<PQLS.PartialSemanticToken> = tokens
+        .slice()
+        .sort((left: PQLS.PartialSemanticToken, right: PQLS.PartialSemanticToken) => {
+            const lineDiff: number = left.range.start.line - right.range.start.line;
+
+            return lineDiff !== 0 ? lineDiff : left.range.start.character - right.range.start.character;
+        });
+
+    const encoded: number[] = [];
+    let prevLine: number = 0;
+    let prevCharacter: number = 0;
+
+    for (const token of sorted) {
+        const tokenTypeIndex: number = semanticTokenTypesLegend.indexOf(token.tokenType);
+
+        if (tokenTypeIndex === -1) {
+            continue;
+        }
+
+        // Skip multi-line tokens — LSP semantic tokens encoding requires single-line tokens
+        if (token.range.end.line !== token.range.start.line) {
+            continue;
+        }
+
+        const length: number = token.range.end.character - token.range.start.character;
+
+        if (length <= 0) {
+            continue;
+        }
+
+        const line: number = token.range.start.line;
+        const character: number = token.range.start.character;
+        const deltaLine: number = line - prevLine;
+        const deltaStartCharacter: number = deltaLine === 0 ? character - prevCharacter : character;
+
+        let tokenModifiersBitmask: number = 0;
+
+        for (const modifier of token.tokenModifiers) {
+            const index: number = semanticTokenModifiersLegend.indexOf(modifier);
+
+            if (index !== -1) {
+                tokenModifiersBitmask |= 1 << index;
+            }
+        }
+
+        encoded.push(deltaLine, deltaStartCharacter, length, tokenTypeIndex, tokenModifiersBitmask);
+
+        prevLine = line;
+        prevCharacter = character;
+    }
+
+    return encoded;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,16 +9,12 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 
 import * as ErrorUtils from "./errorUtils";
 import * as EventHandlerUtils from "./eventHandlerUtils";
+import * as SemanticTokens from "./semanticTokens";
 import * as TraceManagerUtils from "./traceManagerUtils";
 import { ExternalLibraryUtils, LibraryUtils, ModuleLibraryUtils } from "./library";
 import { SettingsUtils } from "./settings";
 
 type LibraryJson = ReadonlyArray<PQLS.LibrarySymbol.LibrarySymbol>;
-
-// interface SemanticTokenParams {
-//     readonly textDocumentUri: string;
-//     readonly cancellationToken: LS.CancellationToken;
-// }
 
 interface ModuleLibraryUpdatedParams {
     readonly workspaceUriPath: string;
@@ -309,6 +305,10 @@ connection.onInitialize((params: LS.InitializeParams) => {
         },
         hoverProvider: true,
         renameProvider: true,
+        semanticTokensProvider: {
+            full: true,
+            legend: SemanticTokens.semanticTokensLegend,
+        },
         signatureHelpProvider: {
             triggerCharacters: ["(", ","],
         },
@@ -379,28 +379,42 @@ connection.onRenameRequest((params: LS.RenameParams, cancellationToken: LS.Cance
     ),
 );
 
-// connection.onRequest("powerquery/semanticTokens", async (params: SemanticTokenParams) => {
-//     const document: TextDocument | undefined = documents.get(params.textDocumentUri);
+connection.languages.semanticTokens.on((params: LS.SemanticTokensParams, cancellationToken: LS.CancellationToken) =>
+    EventHandlerUtils.runSafeAsync<LS.SemanticTokens, void>(
+        runtime,
+        async (): Promise<LS.SemanticTokens> => {
+            const document: TextDocument | undefined = documents.get(params.textDocument.uri);
 
-//     if (document === undefined) {
-//         return [];
-//     }
+            if (document === undefined) {
+                return { data: [] };
+            }
 
-//     const pqpCancellationToken: PQP.ICancellationToken = SettingsUtils.createCancellationToken(undefined);
-//     const traceManager: PQP.Trace.TraceManager =TraceManagerUtils.createTraceManager(document.uri, "semanticTokens");
-//     const analysis: PQLS.Analysis = createAnalysis(document, traceManager);
+            const pqpCancellationToken: PQP.ICancellationToken =
+                SettingsUtils.createCancellationToken(cancellationToken);
 
-//     const result: PQP.Result<PQLS.PartialSemanticToken[] | undefined, PQP.CommonError.CommonError> =
-//         await analysis.getPartialSemanticTokens(pqpCancellationToken);
+            const traceManager: PQP.Trace.TraceManager = TraceManagerUtils.createTraceManager(
+                params.textDocument.uri,
+                "onSemanticTokens",
+            );
 
-//     if (PQP.ResultUtils.isOk(result)) {
-//         return result.value ?? [];
-//     } else {
-//         ErrorUtils.handleError(connection, result.error, "semanticTokens", traceManager);
+            const analysis: PQLS.Analysis = createAnalysis(document, traceManager);
 
-//         return [];
-//     }
-// });
+            const result: PQP.Result<PQLS.PartialSemanticToken[] | undefined, PQP.CommonError.CommonError> =
+                await analysis.getPartialSemanticTokens(pqpCancellationToken);
+
+            if (PQP.ResultUtils.isOk(result) && result.value) {
+                return { data: SemanticTokens.encodeSemanticTokens(result.value) };
+            } else if (PQP.ResultUtils.isError(result)) {
+                ErrorUtils.handleError(connection, result.error, "onSemanticTokens", traceManager);
+            }
+
+            return { data: [] };
+        },
+        { data: [] },
+        `Error while computing semantic tokens for ${params.textDocument.uri}`,
+        cancellationToken,
+    ),
+);
 
 connection.onRequest(
     "powerquery/moduleLibraryUpdated",

--- a/server/src/test/semanticTokens.test.ts
+++ b/server/src/test/semanticTokens.test.ts
@@ -1,0 +1,366 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as PQLS from "@microsoft/powerquery-language-services";
+import * as PQP from "@microsoft/powerquery-parser";
+import { expect } from "chai";
+
+import { encodeSemanticTokens, semanticTokensLegend } from "../semanticTokens";
+import { LibrarySymbolUtils, LibraryUtils } from "../library";
+
+const defaultLibrary: PQLS.Library.ILibrary = LibraryUtils.createLibrary(
+    [LibrarySymbolUtils.getSymbolsForLocaleAndMode(PQP.Locale.en_US, "Power Query")],
+    [],
+);
+
+class NoOpCancellationToken implements PQP.ICancellationToken {
+    isCancelled: () => boolean = () => false;
+    throwIfCancelled: () => void = () => {};
+    cancel: () => void = () => {};
+}
+
+const NoOpCancellationTokenInstance: NoOpCancellationToken = new NoOpCancellationToken();
+
+function createAnalysis(text: string): PQLS.Analysis {
+    const analysisSettings: PQLS.AnalysisSettings = {
+        inspectionSettings: PQLS.InspectionUtils.inspectionSettings(PQP.DefaultSettings, {
+            library: defaultLibrary,
+        }),
+        isWorkspaceCacheAllowed: false,
+        traceManager: PQP.Trace.NoOpTraceManagerInstance,
+        initialCorrelationId: undefined,
+    };
+
+    return PQLS.AnalysisUtils.analysis(PQLS.textDocument("", 1, text), analysisSettings);
+}
+
+async function getPartialSemanticTokens(text: string): Promise<ReadonlyArray<PQLS.PartialSemanticToken>> {
+    const analysis: PQLS.Analysis = createAnalysis(text);
+
+    const result: PQP.Result<ReadonlyArray<PQLS.PartialSemanticToken> | undefined, PQP.CommonError.CommonError> =
+        await analysis.getPartialSemanticTokens(NoOpCancellationTokenInstance);
+
+    PQP.ResultUtils.assertIsOk(result);
+
+    return result.value ?? [];
+}
+
+interface AbridgedSemanticToken {
+    readonly tokenType: string;
+    readonly tokenModifiers: ReadonlyArray<string>;
+    readonly range: string;
+}
+
+function abridgeToken(token: PQLS.PartialSemanticToken): AbridgedSemanticToken {
+    return {
+        tokenType: token.tokenType,
+        tokenModifiers: token.tokenModifiers,
+        range: `${token.range.start.line}:${token.range.start.character}-${token.range.end.line}:${token.range.end.character}`,
+    };
+}
+
+function abridgeTokens(tokens: ReadonlyArray<PQLS.PartialSemanticToken>): ReadonlyArray<AbridgedSemanticToken> {
+    return tokens.map(abridgeToken);
+}
+
+/** Sort tokens by position for deterministic assertions. */
+function sortByPosition(tokens: ReadonlyArray<AbridgedSemanticToken>): ReadonlyArray<AbridgedSemanticToken> {
+    return tokens.slice().sort((a: AbridgedSemanticToken, b: AbridgedSemanticToken) => {
+        const [aStartLine, aStartChar]: ReadonlyArray<number> = a.range.split("-")[0].split(":").map(Number);
+        const [bStartLine, bStartChar]: ReadonlyArray<number> = b.range.split("-")[0].split(":").map(Number);
+        const lineDiff: number = aStartLine - bStartLine;
+
+        return lineDiff !== 0 ? lineDiff : aStartChar - bStartChar;
+    });
+}
+
+describe("semanticTokens", () => {
+    describe("semanticTokensLegend", () => {
+        it("includes all expected token types", () => {
+            const expected: ReadonlyArray<string> = [
+                "variable",
+                "function",
+                "parameter",
+                "property",
+                "keyword",
+                "number",
+                "string",
+                "comment",
+                "type",
+                "namespace",
+                "operator",
+                "typeParameter",
+                "modifier",
+            ];
+
+            expect(semanticTokensLegend.tokenTypes).to.deep.equal(expected);
+        });
+
+        it("includes all expected token modifiers", () => {
+            const expected: ReadonlyArray<string> = [
+                "declaration",
+                "definition",
+                "readonly",
+                "defaultLibrary",
+                "deprecated",
+            ];
+
+            expect(semanticTokensLegend.tokenModifiers).to.deep.equal(expected);
+        });
+    });
+
+    describe("getPartialSemanticTokens", () => {
+        it("returns empty tokens for empty input", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("");
+            expect(tokens).to.deep.equal([]);
+        });
+
+        // let x = 1 in x
+        //  0123456789...
+        it("tokenizes a simple let expression", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("let x = 1 in x");
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // let
+                { tokenType: "keyword", tokenModifiers: [], range: "0:0-0:3" },
+                // x (decl)
+                { tokenType: "variable", tokenModifiers: ["declaration", "readonly"], range: "0:4-0:5" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:8-0:9" },
+                // in
+                { tokenType: "keyword", tokenModifiers: [], range: "0:10-0:12" },
+                // x (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "0:13-0:14" },
+            ]);
+        });
+
+        it("tokenizes a string literal", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens('"hello"');
+
+            expect(abridgeTokens(tokens)).to.deep.equal([
+                { tokenType: "string", tokenModifiers: [], range: "0:0-0:7" },
+            ]);
+        });
+
+        it("tokenizes a library reference", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("List.Count");
+
+            expect(abridgeTokens(tokens)).to.deep.equal([
+                { tokenType: "variable", tokenModifiers: ["defaultLibrary"], range: "0:0-0:10" },
+            ]);
+        });
+
+        it("tokenizes a library function invocation", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("List.Count({1})");
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // List.Count (invocation)
+                { tokenType: "function", tokenModifiers: [], range: "0:0-0:10" },
+                // List.Count (library ref)
+                { tokenType: "variable", tokenModifiers: ["defaultLibrary"], range: "0:0-0:10" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:12-0:13" },
+            ]);
+        });
+
+        it("tokenizes a multi-line let expression", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens(
+                "let\n    x = 1,\n    y = x + 2\nin\n    y",
+            );
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // let
+                { tokenType: "keyword", tokenModifiers: [], range: "0:0-0:3" },
+                // x (decl)
+                { tokenType: "variable", tokenModifiers: ["declaration", "readonly"], range: "1:4-1:5" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "1:8-1:9" },
+                // y (decl)
+                { tokenType: "variable", tokenModifiers: ["declaration", "readonly"], range: "2:4-2:5" },
+                // x (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "2:8-2:9" },
+                // +
+                { tokenType: "operator", tokenModifiers: [], range: "2:10-2:11" },
+                // 2
+                { tokenType: "number", tokenModifiers: [], range: "2:12-2:13" },
+                // in
+                { tokenType: "keyword", tokenModifiers: [], range: "3:0-3:2" },
+                // y (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "4:4-4:5" },
+            ]);
+        });
+
+        it("tokenizes mixed types on a single line", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens(
+                'let x = 1, y = "hello" in x + y',
+            );
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // let
+                { tokenType: "keyword", tokenModifiers: [], range: "0:0-0:3" },
+                // x (decl)
+                { tokenType: "variable", tokenModifiers: ["declaration", "readonly"], range: "0:4-0:5" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:8-0:9" },
+                // y (decl)
+                { tokenType: "variable", tokenModifiers: ["declaration", "readonly"], range: "0:11-0:12" },
+                // "hello"
+                { tokenType: "string", tokenModifiers: [], range: "0:15-0:22" },
+                // in
+                { tokenType: "keyword", tokenModifiers: [], range: "0:23-0:25" },
+                // x (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "0:26-0:27" },
+                // +
+                { tokenType: "operator", tokenModifiers: [], range: "0:28-0:29" },
+                // y (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "0:30-0:31" },
+            ]);
+        });
+
+        // let f = (x) => x in f(1)
+        // 0         1         2
+        // 0123456789012345678901234
+        it("tokenizes function parameters", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> =
+                await getPartialSemanticTokens("let f = (x) => x in f(1)");
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // let
+                { tokenType: "keyword", tokenModifiers: [], range: "0:0-0:3" },
+                // f (decl)
+                { tokenType: "function", tokenModifiers: ["declaration", "readonly"], range: "0:4-0:5" },
+                // x (parameter decl)
+                { tokenType: "parameter", tokenModifiers: ["declaration"], range: "0:9-0:10" },
+                // x (ref in body)
+                { tokenType: "variable", tokenModifiers: [], range: "0:15-0:16" },
+                // in
+                { tokenType: "keyword", tokenModifiers: [], range: "0:17-0:19" },
+                // f (invocation)
+                { tokenType: "function", tokenModifiers: [], range: "0:20-0:21" },
+                // f (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "0:20-0:21" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:22-0:23" },
+            ]);
+        });
+
+        // let f = (x as number) => x in f(1)
+        // 0         1         2         3
+        // 0123456789012345678901234567890123
+        it("tokenizes typed function parameters with type annotations", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens(
+                "let f = (x as number) => x in f(1)",
+            );
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // let
+                { tokenType: "keyword", tokenModifiers: [], range: "0:0-0:3" },
+                // f (decl)
+                { tokenType: "function", tokenModifiers: ["declaration", "readonly"], range: "0:4-0:5" },
+                // x (parameter decl)
+                { tokenType: "parameter", tokenModifiers: ["declaration"], range: "0:9-0:10" },
+                // as
+                { tokenType: "keyword", tokenModifiers: [], range: "0:11-0:13" },
+                // number (type annotation)
+                { tokenType: "type", tokenModifiers: [], range: "0:14-0:20" },
+                // x (ref in body)
+                { tokenType: "variable", tokenModifiers: [], range: "0:25-0:26" },
+                // in
+                { tokenType: "keyword", tokenModifiers: [], range: "0:27-0:29" },
+                // f (invocation)
+                { tokenType: "function", tokenModifiers: [], range: "0:30-0:31" },
+                // f (ref)
+                { tokenType: "variable", tokenModifiers: [], range: "0:30-0:31" },
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:32-0:33" },
+            ]);
+        });
+
+        it("tokenizes type assertions", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("1 as number");
+
+            expect(sortByPosition(abridgeTokens(tokens))).to.deep.equal([
+                // 1
+                { tokenType: "number", tokenModifiers: [], range: "0:0-0:1" },
+                // as
+                { tokenType: "keyword", tokenModifiers: [], range: "0:2-0:4" },
+                // number
+                { tokenType: "type", tokenModifiers: [], range: "0:5-0:11" },
+            ]);
+        });
+    });
+
+    describe("encodeSemanticTokens", () => {
+        it("returns empty array for empty input", () => {
+            expect(encodeSemanticTokens([])).to.deep.equal([]);
+        });
+
+        it("encodes real tokens from a let expression", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens("let x = 1 in x");
+
+            const encoded: ReadonlyArray<number> = encodeSemanticTokens(tokens);
+
+            // Each token produces 5 numbers: [deltaLine, deltaStartChar, length, tokenTypeIndex, modifiersBitmask]
+            expect(encoded.length % 5).to.equal(0);
+            expect(encoded.length).to.be.greaterThan(0);
+
+            // All values should be non-negative integers
+            for (const value of encoded) {
+                expect(value).to.be.at.least(0);
+                expect(Number.isInteger(value)).to.equal(true);
+            }
+        });
+
+        it("produces monotonically increasing positions when decoded", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens(
+                "let\n    x = 1,\n    y = x + 2\nin\n    y",
+            );
+
+            const encoded: ReadonlyArray<number> = encodeSemanticTokens(tokens);
+
+            let absoluteLine: number = 0;
+            let absoluteChar: number = 0;
+            let prevLine: number = -1;
+            let prevChar: number = -1;
+
+            for (let i: number = 0; i < encoded.length; i += 5) {
+                const deltaLine: number = encoded[i];
+                const deltaChar: number = encoded[i + 1];
+
+                absoluteLine += deltaLine;
+                absoluteChar = deltaLine === 0 ? absoluteChar + deltaChar : deltaChar;
+
+                if (absoluteLine === prevLine) {
+                    expect(absoluteChar).to.be.greaterThan(prevChar, "tokens on same line must advance in character");
+                } else {
+                    expect(absoluteLine).to.be.greaterThan(prevLine, "tokens must advance in line");
+                }
+
+                prevLine = absoluteLine;
+                prevChar = absoluteChar;
+            }
+        });
+
+        it("all token type indices are within legend bounds", async () => {
+            const tokens: ReadonlyArray<PQLS.PartialSemanticToken> = await getPartialSemanticTokens(
+                'let x = 1, y = "hello" in x + y',
+            );
+
+            const encoded: ReadonlyArray<number> = encodeSemanticTokens(tokens);
+
+            for (let i: number = 3; i < encoded.length; i += 5) {
+                expect(encoded[i]).to.be.at.least(0);
+                expect(encoded[i]).to.be.lessThan(semanticTokensLegend.tokenTypes.length);
+            }
+        });
+
+        it("does not mutate the input array", async () => {
+            const tokens: PQLS.PartialSemanticToken[] = [...(await getPartialSemanticTokens("let x = 1 in x"))];
+
+            const originalFirst: PQLS.PartialSemanticToken = tokens[0];
+            encodeSemanticTokens(tokens);
+
+            expect(tokens[0]).to.equal(originalFirst);
+        });
+    });
+});


### PR DESCRIPTION
﻿Enables semantic highlighting by implementing the standard LSP textDocument/semanticTokens/full protocol, replacing
the previously scaffolded but disabled custom request approach.

Changes:

 - server/src/semanticTokens.ts (new) — Token legend and delta-encoding logic, extracted into its own module. 
Encodes PartialSemanticToken[] from PQLS into the LSP wire format.
 - server/src/server.ts — Advertises semanticTokensProvider capability and handles textDocument/semanticTokens/full 
via connection.languages.semanticTokens.on(...). Removed commented-out custom powerquery/semanticTokens handler.
 - client/src/extension.ts — Removed commented-out client-side provider registration (vscode-languageclient handles 
this automatically when the server advertises the capability).
 - package.json — Added semanticTokenScopes mapping 14 token types to TextMate scopes for theme coloring.
 - server/src/test/semanticTokens.test.ts (new) — Tests covering legend correctness, real PQLS analysis output for 
all emitted token types (variable, function, parameter, keyword, number, string, type, operator), and encoding 
invariants (monotonic positions, legend bounds, immutability).

Token legend: 13 types (variable, function, parameter, property, keyword, number, string, comment, type, namespace,
operator, typeParameter, modifier) and 5 modifiers (declaration, definition, readonly, defaultLibrary, deprecated).